### PR TITLE
Delete robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-# TODO - remove before final deploy
-User-agent: *
-Disallow: /


### PR DESCRIPTION
Per Trello:

"Google search results for "tutoria.io" show our site but not the site description"

robots.txt in public folder set to `Disallow: /`, telling any web crawler to ignore the whole site.

I see no reason to have a robots.txt file at all, as the admin settings will be protected by the authorization we have in place, but definitely open to simply revising it if we want any web crawlers to ignore certain parts of the site.