### PR TITLE
Update last logged in to current sign in

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -16,6 +16,7 @@ class UserDecorator
       :first_name => first_name,
       :languages => languages,
       :last_logged_in => last_logged_in,
+      :current_sign_in => current_sign_in,
       :locale => locale,
       :phone_number => phone_number,
       :programs => programs,
@@ -174,6 +175,14 @@ class UserDecorator
   def last_logged_in
     if @user.last_sign_in_at?
       time_ago_in_words(@user.last_sign_in_at)
+    else
+      nil
+    end
+  end
+
+  def current_sign_in
+    if @user.current_sign_in_at?
+      time_ago_in_words(@user.current_sign_in_at)
     else
       nil
     end

--- a/app/javascript/components/SearchResults.js
+++ b/app/javascript/components/SearchResults.js
@@ -161,7 +161,7 @@ class SearchResults extends Component {
       const { currentUser: { locale }, currentUser, history } = this.props;
       const { search } = this.state;
 
-      return _.map(_.values(volunteers), ({ state, country, rating_count, languages, average_rating, thumbnail_image, first_name, city, last_logged_in, programs, url_slug }, key) => {
+      return _.map(_.values(volunteers), ({ state, country, rating_count, languages, average_rating, thumbnail_image, first_name, city, current_sign_in, programs, url_slug }, key) => {
         return [
           <SearchResultItem
             locale={ locale }
@@ -170,7 +170,7 @@ class SearchResults extends Component {
             isCurrentUserLocated={ isCurrentUserLocated(currentUser) }
             firstName={ first_name }
             avatar={ thumbnail_image }
-            lastLoggedin={ last_logged_in }
+            lastLoggedin={ current_sign_in }
             city={ city }
             state={ state }
             country={ country }

--- a/app/models/concerns/has_user_search.rb
+++ b/app/models/concerns/has_user_search.rb
@@ -52,13 +52,13 @@ module HasUserSearch
         when "closest"
           near(current_full_address, 10000, :order => "")
         when 'last'
-          order(last_sign_in_at: :desc)
+          order(current_sign_in_at: :desc)
         else
           message = I18n.t('custom_errors.messages.incorrect_order')
           raise Contexts::Availabilities::Errors::IncorrectOrder, message
         end
       else
-        order(last_sign_in_at: :desc)
+        order(current_sign_in_at: :desc)
       end
     }
 


### PR DESCRIPTION
Fix for the task
"In volunteer search results, Last Login time should refer to field [Current Sign In At], not [Last Sign In At]"

Few things are done here:

Update front end to get current_sign_in.
Update backend to get current_sign_in from decorator.
Change the default sorting of volunteer search to sort by currently current_sign_in_at desc.
Recently Logged in is updated to reference to current_sign_in