### PR TITLE
Admin panel active button checkoff email fix

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -5,6 +5,16 @@ ActiveAdmin.register User do
       user.admin_user_creation!
       redirect_to(admin_user_path(user))
     end
+    def update
+      @active = User.find(params[:id]).try(:active)
+      super
+      if @user.active == true
+        # send email here
+        resource.activate_account!
+      else
+        resource.deactivate_account!
+      end
+    end
   end
 
   permit_params :email,


### PR DESCRIPTION
This commit fixes a bug where when you go into the admin panel and check/uncheck active checkbox for a particular user and hit update user it won't send them an email. This should fix it and send the appropriate email to the appropriate parties.