### PR TITLE
fix bug when midnight 00:00 is used as the end time

### DIFF
--- a/app/models/concerns/has_user_search.rb
+++ b/app/models/concerns/has_user_search.rb
@@ -84,7 +84,11 @@ module HasUserSearch
                         end
 
           end_query = if params[:end_time]
-                        Time.zone.parse("#{day_month} #{params[:end_time]}")&.utc
+                        if params[:end_time] == "0:00"
+                          Time.zone.parse("#{day_month} 23:59")&.utc
+                        else
+                          Time.zone.parse("#{day_month} #{params[:end_time]}")&.utc
+                        end
                       else
                         end_of_day
                       end


### PR DESCRIPTION
Currently, 00:00 as end time in user search will be translated to the start of the day instead of the end of the day. Hence, wrong search query will be generated. As a result, no user will be returned because the end time 00:00 is never later than any start time.

Since the latest end time is 23:39 while creating new availability, we need to translate the end time 00:00 to 23:59 for user search to solve the problem.