### PR TITLE
Use href links instead of React Links in header

### DIFF
--- a/app/javascript/components/reusable/withStyles/StyledSliderButton.js
+++ b/app/javascript/components/reusable/withStyles/StyledSliderButton.js
@@ -4,9 +4,6 @@ import {
     withStyles
 } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import {
-    Link
-} from 'react-router-dom';
 
 const styles = {
     button: {
@@ -97,8 +94,7 @@ const styles = {
             <span id='slider-button-container' className='sliderButtonContainer'>
               <Button
                 className={ grey ? classes.greyButton : classes.button }
-                component={ to === '' ? undefined : Link }
-                to={ to }
+                href={ to }
                 disableFocusRipple
                 { ...other }
                 >


### PR DESCRIPTION
This changes the buttons in the header to use normal href links rather than React ones. This forces a full server-side reload of the page, which fixes a number of bugs in which missing data causes pages to be incorrectly rendered until reloaded.