### PR TITLE
Pre-populate more fields in volunteer search.

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -9,15 +9,16 @@ class AvailabilitiesController < ApplicationController
     programs = Program.all
     languages = Language.all
     days = I18n.translate 'date.day_names'
-
     @data = {
         :currentUser => user,
-        :programs => programs,
         :languages => languages,
+        :programs => programs,
+        :days => days,
         :search => {
           language: user[:language_ids],
+          program: user[:program_ids],
+          day: (0..6).to_a
         },
-        :days => days
     }
 
     render :search

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -21,6 +21,7 @@ class UserDecorator
       :locale => locale,
       :phone_number => phone_number,
       :programs => programs,
+      :program_ids => program_ids,
       :rating_count => rating_count,
       :state => state,
       :thumbnail_image => picture,
@@ -81,6 +82,7 @@ class UserDecorator
         :locale => locale,
         :phone_number => phone_number,
         :programs => programs,
+        :program_ids => program_ids,
         :rating_count => rating_count,
         :state => state,
         :thumbnail_image => picture,
@@ -152,6 +154,10 @@ class UserDecorator
 
   def programs
     @user.programs.pluck(:name)
+  end
+
+  def program_ids
+    @user.programs.pluck(:id)
   end
 
   def address


### PR DESCRIPTION
This pre-populates the program field with the programs the user is interested in (as set in their profile), and the days field with all days.

I think since more than one day can already be selected in the search, it makes more sense to simply have them all selected to begin with rather than having a separate option for "All". Having both an "All" option and all the days and being able to pick multiple seems like confusing UI (what happens if I select three days then also select "All"?).