### PR TITLE
Pointed all users with null city, latitude and longitude to New York

### DIFF
--- a/app/controllers/api/v1/city_controller.rb
+++ b/app/controllers/api/v1/city_controller.rb
@@ -3,7 +3,10 @@ module Api
     class CityController < ApplicationController
       def index
         cities = User.select(:city, :latitude, :longitude).group(:city, :latitude, :longitude)
-                     .where.not(:city => nil, :latitude => nil, :longitude => nil)
+
+        cities.where('city IS NULL OR latitude IS NULL OR longitude IS NULL')
+            .update_all(city: "New York", latitude: 40.7127281, longitude: -74.0060152)
+
         render json: cities , serializer: CitiesSerializer, adapter: :attributes, root: ''
       end
     end


### PR DESCRIPTION
This commit will point all the users with wither null values of city, latitude or longitude to point to New York without affecting the database and also query it just for the Map component.