### PR TITLE
Create availability error handling

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -44,7 +44,7 @@ class AvailabilitiesController < ApplicationController
   def create
     if permitted_params.present?
       message = []
-      status = []
+      status = :ok
 
       permitted_params.each do |key, value|
         creation = Contexts::Availabilities::Creation.new(permit_nested(value), current_user)
@@ -57,13 +57,13 @@ class AvailabilitiesController < ApplicationController
             Contexts::Availabilities::Errors::EndTimeMissing,
             Contexts::Availabilities::Errors::ShortAvailability => e
           message << e.message
-          status << :unprocessable_entity
+          status = :unprocessable_entity
         else
           message << { availability: `#{@availability.id} successfully created` }
         end
       end
 
-      render :json=> { :message => message }, :status => :ok
+      render :json=> { :message => message }, :status => status
     end
   end
 

--- a/app/models/contexts/availabilities/creation.rb
+++ b/app/models/contexts/availabilities/creation.rb
@@ -101,7 +101,7 @@ module Contexts
 
       def parse_time(time)
         t = Time.zone.parse(time)
-        Time.zone.parse(t.strftime("#{@day_index + 1} Jan 2001 %T"))
+        Time.zone.parse(t.strftime("#{@day_index + 1} Jan 2001 %R"))
       end
 
       def initialize_start_time


### PR DESCRIPTION
Related to create availability validity checks:
- corrected http status code (status is ok only if all availabilities successfully created)
- no need to compare seconds (just hours and minutes)
- for db call to create the availability, use 'find or create'.  So if same availability entered multiple times, it is ok.
- modified overlap checks to work as expected.  Note that identical times are not considered an overlap.  This helps with scenario where user entered several availabilities and some were successful and others had errors.  User can correct errors and resubmit (the availabilities previously successfully added will not generate errors).
