### PR TITLE
Overlap availabilities error message

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -59,7 +59,7 @@ class AvailabilitiesController < ApplicationController
           message << e.message
           status = :unprocessable_entity
         else
-          message << { availability: `#{@availability.id} successfully created` }
+          message << nil # no error message for this availability
         end
       end
 

--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -46,23 +46,25 @@ class AvailabilitiesController < ApplicationController
       message = []
       status = :ok
 
-      permitted_params.each do |key, value|
-        creation = Contexts::Availabilities::Creation.new(permit_nested(value), current_user)
+      Availability.transaction do
+        permitted_params.each do |key, value|
+          creation = Contexts::Availabilities::Creation.new(permit_nested(value), current_user)
 
-        begin
-          @availability = creation.execute
-        rescue Contexts::Availabilities::Errors::UnknownAvailabilityError,
-            Contexts::Availabilities::Errors::OverlappingAvailability,
-            Contexts::Availabilities::Errors::StartTimeMissing,
-            Contexts::Availabilities::Errors::EndTimeMissing,
-            Contexts::Availabilities::Errors::ShortAvailability => e
-          message << e.message
-          status = :unprocessable_entity
-        else
-          message << nil # no error message for this availability
+          begin
+            @availability = creation.execute
+          rescue Contexts::Availabilities::Errors::UnknownAvailabilityError,
+              Contexts::Availabilities::Errors::OverlappingAvailability,
+              Contexts::Availabilities::Errors::StartTimeMissing,
+              Contexts::Availabilities::Errors::EndTimeMissing,
+              Contexts::Availabilities::Errors::ShortAvailability => e
+            message << e.message
+            status = :unprocessable_entity
+          else
+            message << nil # no error message for this availability
+          end
         end
+        raise ActiveRecord::Rollback, "create availability errors" if status != :ok
       end
-
       render :json=> { :message => message }, :status => status
     end
   end

--- a/app/models/contexts/availabilities/creation.rb
+++ b/app/models/contexts/availabilities/creation.rb
@@ -67,13 +67,8 @@ module Contexts
             end_time = availability[:end_time].beginning_of_minute
 
             same = (current_range[:start_time] == start_time) && (current_range[:end_time] == end_time)
-            start_overlap = (current_range[:start_time] > start_time) && (current_range[:start_time] < end_time)
-            end_overlap = (current_range[:end_time] > start_time) && (current_range[:end_time] < end_time) 
-
-            # overlap if not exact equal AND either of the following
-            # existing start > new start and < new end
-            # existing end > new start and < new end
-            (!same) && ( start_overlap || end_overlap )
+            overlap = (current_range[:start_time] < end_time) && (current_range[:end_time] > start_time)
+            same || overlap
           end
 
           if overlaps


### PR DESCRIPTION
1) When creating multiple availabilities, corrected bug with error message display.  Problem was in backend (storing wrong message info for valid availabilities)
2) Simplified overlap check logic
3) For multiple availability creation, implemented transaction/rollback.  So if any errors detected, no availabilities are added.   This is to deal with complexities when a user tries to create multiple availabilities, has invalid entries, and then tries to correct by removing valid availabilities from the form.
4) Trying to create a duplicate availability is now an overlap error.