### PR TITLE
Multilang page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,8 @@ class ApplicationController < ActionController::Base
 
     @data = {
         :currentUser => @user,
-        :programs => programs
+        :programs => programs,
+        :locale => I18n.locale.to_s
     }
 
     render :index
@@ -30,7 +31,8 @@ class ApplicationController < ActionController::Base
 
     @data = {
         :currentUser => @user,
-        :page_content => page_content
+        :page_content => page_content,
+        :locale => I18n.locale.to_s
     }
 
     render :custom_page
@@ -47,7 +49,8 @@ class ApplicationController < ActionController::Base
 
     @data = {
         :currentUser => @user,
-        :page_content => page_content
+        :page_content => page_content,
+        :locale => I18n.locale.to_s
     }
 
     render :custom_page
@@ -69,7 +72,8 @@ class ApplicationController < ActionController::Base
 
     @data = {
         :currentUser => @user,
-        :page_content => page_content
+        :page_content => page_content,
+        :locale => I18n.locale.to_s
     }
 
     render :custom_page
@@ -83,7 +87,8 @@ class ApplicationController < ActionController::Base
 
     @data = {
         :currentUser => @user,
-        :terms_and_conditions => terms_and_conditions
+        :terms_and_conditions => terms_and_conditions,
+        :locale => I18n.locale.to_s
     }
 
     render :t_and_c
@@ -93,20 +98,34 @@ class ApplicationController < ActionController::Base
     decorate_user_if_present
 
     @data = {
-        :currentUser => @user
+        :currentUser => @user,
+        :locale => I18n.locale.to_s
     }
   end
   
   def sitemap
-    @languages = ["", "en", "es"] #/ for english
     @pages = ["", "/about", "/faq" , "/sign_up/client", "/sign_up/volunteer", "/terms_of_use" ]
     headers['Content-Type'] = 'application/xml'
     @host = "#{request.protocol}#{request.host}"
   end
 
   def set_locale
+    @languages = ["", "en", "es"]
+    locale_extracted = "en" #default
+    browser_locale = extract_locale_from_headers
+    browser_locale.each do |loc| 
+      if @languages.include? loc
+        locale_extracted = loc
+        break
+      end
+    end
     params.permit(:locale)
-    I18n.locale = params[:locale] || I18n.default_locale
+    I18n.locale = params[:locale] || locale_extracted
+    
+  end
+  
+  def extract_locale_from_headers
+    request.env['HTTP_ACCEPT_LANGUAGE'].scan(/[a-z]{2}/).uniq 
   end
 
   protected

--- a/app/javascript/components/CustomPage.js
+++ b/app/javascript/components/CustomPage.js
@@ -8,12 +8,11 @@ import ChooseLanguage from './utils/ChooseLanguage';
 
 class CustomPage extends Component {
   render() {
-    const { page_content, currentUser } = this.props;
+    const { page_content, currentUser, locale } = this.props;
     const content = function(){
-      if (ChooseLanguage() === 'es' && page_content['es']) {
-        return Parser(page_content['es']);
-      } else if (page_content['en']) {
-        return Parser(page_content['en']);
+    
+      if (locale && page_content) {
+        return Parser(page_content[locale]);
       } else {
         return null;
       }

--- a/app/javascript/components/Homepage.js
+++ b/app/javascript/components/Homepage.js
@@ -172,7 +172,6 @@ class Homepage extends Component {
     this.state = {
       languageChecked: ENGLISH,
       signUpType: 'client',
-      locale: localStorage.getItem('locale'),
       mapView: 'row',
       clientsSelected: true,
       volunteersSelected: true,
@@ -349,10 +348,10 @@ class Homepage extends Component {
             />
             <CardContent>
               <h2 className='programCardsHeader'>
-                { this.state.locale === 'es' ? element.spanish_name : element.name }
+                { this.props.locale === 'es' ? element.spanish_name : element.name }
               </h2>
               <p className='programCardsText'>
-                { this.state.locale === 'es' ? element.spanish_description : element.description }
+                { this.props.locale === 'es' ? element.spanish_description : element.description }
               </p>
             </CardContent>
           </Card>

--- a/app/javascript/components/TermsAndConditions.js
+++ b/app/javascript/components/TermsAndConditions.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Paper from 'material-ui/Paper';
 import Parser from 'html-react-parser';
 
-const TermsAndConditions = ({ currentUser, terms_and_conditions })=> {
+const TermsAndConditions = ({ currentUser, terms_and_conditions, locale })=> {
   const content = function(){
     if (terms_and_conditions) {
       return Parser(terms_and_conditions);

--- a/app/javascript/components/utils/ChooseLanguage.js
+++ b/app/javascript/components/utils/ChooseLanguage.js
@@ -1,17 +1,19 @@
-import _ from 'lodash';
 import { ENGLISH, SPANISH } from './availableLocales';
 
-function ChooseLanguage() {
-  const currentUrl = _.split(window.location.pathname, '/');
+function ChooseLanguage(setLang, languageInferredFromServer) {
+  
+  
+  const re = /(\/[a-z]{2})?(\/.*)?$/
+  let path =  window.location.pathname.match(re);
+
+  if (path[0].includes(`/${ENGLISH}`)) return setLang(ENGLISH)
+  if (path[0].includes(`/${SPANISH}`)) return setLang(SPANISH)
+
   const guestLocale = localStorage.getItem('locale');
+  let defineLocale = guestLocale || languageInferredFromServer;
 
-  if (currentUrl[1] === ENGLISH || currentUrl[1] === SPANISH) {
-    return currentUrl[1];
-  } else if (guestLocale && (guestLocale === ENGLISH|| guestLocale === SPANISH)) {
-    return guestLocale;
-  } else{
-    return ENGLISH;
-  }
+  return window.location.replace(`${window.location.origin}/${defineLocale}${path[2]}`)
+  
 }
-
+  
 export default ChooseLanguage;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,15 +10,17 @@
 import '@babel/polyfill';
 import '../../main.scss';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Joi from 'joi-browser';
 import ReactJoiValidation from 'react-joi-validation';
 import {
   BrowserRouter as Router,
   Route,
   Switch,
-  Redirect
+  Redirect,
+
 } from 'react-router-dom';
+import _ from 'lodash';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
@@ -27,6 +29,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import en from 'react-intl/locale-data/en';
 import es from 'react-intl/locale-data/es';
+import ChooseLanguage from "../components/utils/ChooseLanguage";
 
 import ReactDom from 'react-dom';
 
@@ -53,16 +56,13 @@ import CustomPage from '../components/CustomPage';
 import ConversationPage from '../components/ConversationPage';
 import UserReviewIndexPage from '../components/UserReviewIndexPage';
 
-import ChooseLanguage from '../components/utils/ChooseLanguage';
-
-
 import localeData from '../../../build/locales/data.json';
 
 import { ENGLISH, SPANISH } from '../components/utils/availableLocales';
 
 addLocaleData([ ...en, ...es ]);
-const language = ChooseLanguage();
-const messages = localeData[language];
+
+
 
 const { render }  = ReactDom;
 
@@ -82,62 +82,79 @@ function renderUserProfile(data, props) {
   }
 }
 
+const App = ({pathname, data}) => {
+
+  const [language, setLang] = useState(ENGLISH);
+  const [messages, setMessages] = useState(localeData[ENGLISH]);
+  
+  
+  useEffect(() => ChooseLanguage(setLang, data["locale"]), [])
+  
+  useEffect(() => setMessages(localeData[language]), [language])
+
+  console.log(language);
+  
+  const locale = `(${ENGLISH}|${SPANISH})`;
+
+  return ( 
+    <IntlProvider locale={ language } key={ language }  messages={ messages }>
+        <MuiThemeProvider muiTheme={ getMuiTheme(MuiTheme) }>
+          <Router>
+            <ContentWrapper currentUser={ data.currentUser }>
+              <Switch>
+                <Route exact path={ `/${locale}` } render={ (props) => <Homepage { ...data } { ...props } locale={language} /> } />
+                <Route exact path={ `/${locale}/inbox` } render={ (props) => <ConversationIndexPage { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/inbox/:id` } render={ (props) => <ConversationPage { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/messages/new` } render={ (props) => <NewMessagePage { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/search` } render={ (props) => <SearchBar { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/volunteers` } render={ (props) => <SearchResults { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/my_profile` } render={ (props) => <MyProfile { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/:user_id/(:order)` } render={ (props) => <UserReviewIndexPage { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/reviews/author/:url_slug` } render={ (props) => <UserReviewIndexPage { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/profiles/:url_slug` } render={ (props) => (renderUserProfile (data, props)) } />
+                <Route exact path={ `/${locale}/password/new` } component={ NewPasswordPage } />
+                <Route exact path={ `/${locale}/password/edit` } render={ (props) => <ResetPasswordPage { ...props } /> } />
+                <Route exact path={ `/${locale}/availabilities/new` } render={ (props) => <NewAvailability { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/availabilities` } render={ (props) => <AvailabilityIndexPage { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/about` } render={ (props) => <CustomPage { ...data } { ...props } locale={language} /> } />
+                <Route exact path={ `/${locale}/faq` } render={ (props) => <CustomPage { ...data } { ...props } locale={language} /> } />
+                <Route exact path={ `/${locale}/sign_in` } component={ SignIn } />
+                <Route exact path={ `/${locale}/sign_up/:role` } render={ (props) => <SignUp { ...data } { ...props } /> } />
+                <Route exact path={ `/${locale}/volunteer_sign_up_completed` } render={ (props) => <CustomPage { ...data } { ...props } locale={language}/> } />
+                <Route exact path={ `/${locale}/terms_of_use` } render={ (props) => <TermsAndConditions { ...data } { ...props } /> } />
+                <Route exact path='/' render={ () => <Homepage { ...data } locale={language}/> } />
+                <Route exact path='/inbox' render={ (props) => <ConversationIndexPage { ...data } { ...props } /> } />
+                <Route exact path='/inbox/:id' render={ (props) => <ConversationPage { ...data } { ...props } /> } />
+                <Route exact path='/messages/new' render={ (props) => <NewMessagePage { ...data } { ...props } /> } />
+                <Route exact path='/search' render={ (props) => <SearchBar { ...data } { ...props } /> } />
+                <Route exact path='/volunteers' render={ (props) => <SearchResults { ...data } { ...props } /> } />
+                <Route exact path='/my_profile' render={ (props) => <MyProfile { ...data } { ...props } /> } />
+                <Route exact path='/reviews/author/:url_slug' render={ (props) => <UserReviewIndexPage { ...data } { ...props } /> } />
+                <Route exact path='/profiles/:url_slug' render={ (props) => (renderUserProfile (data, props)) } />
+                <Route exact path='/password/new' component={ NewPasswordPage } />
+                <Route exact path='/password/edit' render={ (props) => <ResetPasswordPage { ...props } /> } />
+                <Route exact path='/availabilities/new' render={ (props) => <NewAvailability { ...data } { ...props } /> } />
+                <Route exact path='/availabilities' render={ (props) => <AvailabilityIndexPage { ...data } { ...props } /> } />
+                <Route exact path='/about' render={ (props) => <CustomPage { ...data } { ...props } locale={language}/> } />
+                <Route exact path='/faq' render={ (props) => <CustomPage { ...data } { ...props } locale={language}/> } />
+                <Route exact path='/sign_in' component={ SignIn } />
+                <Route exact path='/sign_up/:role' render={ (props) => <SignUp { ...data } { ...props } /> } />
+                <Route exact path='/volunteer_sign_up_completed' render={ (props) => <CustomPage { ...data } { ...props } locale={language}/> } />
+                <Route exact path='/terms_of_use' render={ (props) => <TermsAndConditions { ...data } { ...props } locale={language}/> } />
+                <Route path='/*' render={ () => <NotFoundPage { ...data } /> } />
+              </Switch>
+            </ContentWrapper>
+          </Router>
+        </MuiThemeProvider>
+      </IntlProvider>
+   )
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('main');
   const node = document.getElementById('data');
-
   const data = node? JSON.parse(node.getAttribute('data')): {};
-  const locale = `(${ENGLISH}|${SPANISH})`;
 
   render(
-    <IntlProvider locale={ language } messages={ messages }>
-      <MuiThemeProvider muiTheme={ getMuiTheme(MuiTheme) }>
-        <Router>
-          <ContentWrapper currentUser={ data.currentUser }>
-            <Switch>
-              <Route exact path={ `/${locale}` } render={ (props) => <Homepage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/inbox` } render={ (props) => <ConversationIndexPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/inbox/:id` } render={ (props) => <ConversationPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/messages/new` } render={ (props) => <NewMessagePage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/search` } render={ (props) => <SearchBar { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/volunteers` } render={ (props) => <SearchResults { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/my_profile` } render={ (props) => <MyProfile { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/:user_id/(:order)` } render={ (props) => <UserReviewIndexPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/reviews/author/:url_slug` } render={ (props) => <UserReviewIndexPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/profiles/:url_slug` } render={ (props) => (renderUserProfile (data, props)) } />
-              <Route exact path={ `/${locale}/password/new` } component={ NewPasswordPage } />
-              <Route exact path={ `/${locale}/password/edit` } render={ (props) => <ResetPasswordPage { ...props } /> } />
-              <Route exact path={ `/${locale}/availabilities/new` } render={ (props) => <NewAvailability { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/availabilities` } render={ (props) => <AvailabilityIndexPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/about` } render={ (props) => <CustomPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/faq` } render={ (props) => <CustomPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/sign_in` } component={ SignIn } />
-              <Route exact path={ `/${locale}/sign_up/:role` } render={ (props) => <SignUp { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/volunteer_sign_up_completed` } render={ (props) => <CustomPage { ...data } { ...props } /> } />
-              <Route exact path={ `/${locale}/terms_of_use` } render={ (props) => <TermsAndConditions { ...data } { ...props } /> } />
-              <Route exact path='/' render={ () => <Homepage { ...data } /> } />
-              <Route exact path='/inbox' render={ (props) => <ConversationIndexPage { ...data } { ...props } /> } />
-              <Route exact path='/inbox/:id' render={ (props) => <ConversationPage { ...data } { ...props } /> } />
-              <Route exact path='/messages/new' render={ (props) => <NewMessagePage { ...data } { ...props } /> } />
-              <Route exact path='/search' render={ (props) => <SearchBar { ...data } { ...props } /> } />
-              <Route exact path='/volunteers' render={ (props) => <SearchResults { ...data } { ...props } /> } />
-              <Route exact path='/my_profile' render={ (props) => <MyProfile { ...data } { ...props } /> } />
-              <Route exact path='/reviews/author/:url_slug' render={ (props) => <UserReviewIndexPage { ...data } { ...props } /> } />
-              <Route exact path='/profiles/:url_slug' render={ (props) => (renderUserProfile (data, props)) } />
-              <Route exact path='/password/new' component={ NewPasswordPage } />
-              <Route exact path='/password/edit' render={ (props) => <ResetPasswordPage { ...props } /> } />
-              <Route exact path='/availabilities/new' render={ (props) => <NewAvailability { ...data } { ...props } /> } />
-              <Route exact path='/availabilities' render={ (props) => <AvailabilityIndexPage { ...data } { ...props } /> } />
-              <Route exact path='/about' render={ (props) => <CustomPage { ...data } { ...props } /> } />
-              <Route exact path='/faq' render={ (props) => <CustomPage { ...data } { ...props } /> } />
-              <Route exact path='/sign_in' component={ SignIn } />
-              <Route exact path='/sign_up/:role' render={ (props) => <SignUp { ...data } { ...props } /> } />
-              <Route exact path='/volunteer_sign_up_completed' render={ (props) => <CustomPage { ...data } { ...props } /> } />
-              <Route exact path='/terms_of_use' render={ (props) => <TermsAndConditions { ...data } { ...props } /> } />
-              <Route path='/*' render={ () => <NotFoundPage { ...data } /> } />
-            </Switch>
-          </ContentWrapper>
-        </Router>
-      </MuiThemeProvider>
-    </IntlProvider>, container);
+    <App pathname={window.location.pathname} data={data}/> , container);
 });


### PR DESCRIPTION
A number of changes to:

-get language inferred from user browser.
-Auto-redirect to correct link /es or /en if the user doesn't specify it. 
-set language from path instead of confusing math that was being used.
- Language now uses react state/effects instead of vanilla JS static global vars.
-IF language preference is saved in cookie by user choice in profile or through menu choice site will prefer it over inferred language. 

This PR probably needs a lot of review specially because FAQ and terms and condition pages are not available in local versions and of course there are things yet to improve.