### PR TITLE
Fixed snackbar not rendering bug, darkened signup labels, fixed card css

### DIFF
--- a/app/javascript/components/NewPasswordPage.js
+++ b/app/javascript/components/NewPasswordPage.js
@@ -58,7 +58,7 @@ class NewPasswordPage extends Component {
           <TextField
             name='email'
             value={ email }
-            className='signUpEmailInputField'
+            className='signInEmailInputField'
             hintText=''
             floatingLabelText={ <FormattedMessage id='NewPasswordPage.enterEmail' defaultMessage='Please enter your email to recover your password' /> }
             floatingLabelFixed

--- a/app/javascript/components/SearchResultItem.js
+++ b/app/javascript/components/SearchResultItem.js
@@ -21,7 +21,6 @@ class SearchResultItem extends Component {
     return (
       <Card className='searchResultItemCard'>
         <CardHeader
-          style={ { height: '245px' } }
           title={ firstName }
           subtitle={ (
             <div className='searchResultItemDetails'>
@@ -45,7 +44,7 @@ class SearchResultItem extends Component {
                 averageRating={ averageRating }
               />
             </div>
-) }
+          ) }
           avatar={ this.renderAvatar() }
         />
         <MessageButtons
@@ -53,12 +52,14 @@ class SearchResultItem extends Component {
           newMessageRecipient={ urlSlug }
           locale={ locale }
           messageType={ MessageTypes.SEND }
+          handleViewProfileClick={ this.handleViewProfileClick }
         />
       </Card>
     );
   }
 
   handleViewProfileClick() {
+ 
     const { urlSlug: url_slug, search, history, volunteers, locale } = this.props;
 
     history.push(formatLink(`/profiles/${url_slug}`, locale), { ...{ search }, volunteers });

--- a/app/javascript/components/SearchResults.js
+++ b/app/javascript/components/SearchResults.js
@@ -43,7 +43,6 @@ class SearchResults extends Component {
 
   render() {
     const { currentUser } = this.props;
-
     return (
       <div>
         <div className='searchResultsContainer'>

--- a/app/javascript/components/SignIn.js
+++ b/app/javascript/components/SignIn.js
@@ -66,7 +66,7 @@ class SignIn extends Component {
           <TextField
             name='email'
             value={ email }
-            className='signUpEmailInputField'
+            className='signInEmailInputField'
             hintText=''
             floatingLabelText='Email'
             floatingLabelFixed
@@ -87,7 +87,7 @@ class SignIn extends Component {
             onChange={ changeHandler('password') }
             onBlur={ validateHandler('password') }
             fullWidth
-            className='signUpEmailInputField'
+            className='signInEmailInputField'
           />
 
           <Checkbox

--- a/app/javascript/components/SignIn.js
+++ b/app/javascript/components/SignIn.js
@@ -87,6 +87,7 @@ class SignIn extends Component {
             onChange={ changeHandler('password') }
             onBlur={ validateHandler('password') }
             fullWidth
+            className='signUpEmailInputField'
           />
 
           <Checkbox

--- a/app/javascript/components/UserProfile.js
+++ b/app/javascript/components/UserProfile.js
@@ -99,7 +99,6 @@ class UserProfile extends Component {
         review
       } = this.props;
       const { comments } = this.state;
-
       return (
         <div>
           { this.renderBackButton() }
@@ -184,24 +183,20 @@ class UserProfile extends Component {
   }
 
   renderBackButton() {
-    const { location: { state } } = this.props;
-
-    if (state && state.search) {
-      return (
-        <div className='userProfileBackButton'>
-          <FlatButton
-            primary
-            label={
-              <FormattedMessage
-                id='UserProfile.Back'
-                defaultMessage='Back to search results'
-              />
-            }
-            onClick={ this.handleViewProfileClick }
-          />
-        </div>
-      );
-    }
+    return (
+      <div className='userProfileBackButton'>
+        <FlatButton
+          primary
+          label={
+            <FormattedMessage
+              id='UserProfile.Back'
+              defaultMessage='Back to search results'
+            />
+          }
+          onClick={ this.handleViewProfileClick }
+        />
+      </div>
+    );
   }
 
   handleViewProfileClick() {
@@ -273,8 +268,6 @@ class UserProfile extends Component {
       );
     }
   }
-
-
 
   renderSnackBar() {
     if (this.state.showSnackBar) {

--- a/app/javascript/components/reusable/Header.js
+++ b/app/javascript/components/reusable/Header.js
@@ -149,7 +149,7 @@ class Header extends Component {
             </ExpansionPanelDetails>
           </ExpansionPanel>
           <SnackBarComponent
-            isOpen={ this.state.showSnackBar }
+            open={ this.state.showSnackBar }
             message={ this.state.message }
             handleClose={ this.handleHideSnackBar }
           />
@@ -186,7 +186,7 @@ class Header extends Component {
             </Toolbar>
           </AppBar>
           <SnackBarComponent
-            isOpen={ this.state.showSnackBar }
+            open={ this.state.showSnackBar }
             message={ this.state.message }
             handleClose={ this.handleHideSnackBar }
           />

--- a/app/javascript/components/reusable/MessageButtons.js
+++ b/app/javascript/components/reusable/MessageButtons.js
@@ -24,9 +24,9 @@ export const MessageTypes = {
 class MessageButtons extends Component {
 
   render() {
-      const { locale, newMessageRecipient, newMessageFirstName, messageType } = this.props;
+    const { locale, newMessageRecipient, newMessageFirstName, messageType, handleViewProfileClick  } = this.props;
     return (
-      <CardActions>
+      <CardActions className="message-buttons">
         <Link to={ { pathname: formatLink('/messages/new', locale), query: { recipient: newMessageRecipient, userName: newMessageFirstName } } }>
           <RaisedButton
             className='messageButtonItem'
@@ -54,7 +54,7 @@ class MessageButtons extends Component {
                 />
                 ) }
             primary
-            onClick={ this.handleViewProfileClick }
+            onClick={ handleViewProfileClick }
             />
         </a>
       </CardActions>

--- a/app/javascript/components/reusable/SnackBarComponent.js
+++ b/app/javascript/components/reusable/SnackBarComponent.js
@@ -14,7 +14,7 @@ class SnackBarComponent extends Component {
     return (
       <Snackbar
         classes={ { root: 'snackBar' } }
-        open={ this.props.isOpen }
+        open={ this.props.open }
       >
         <SnackbarContent
           classes={ { root: 'snackBarContent' } }
@@ -43,7 +43,7 @@ class SnackBarComponent extends Component {
 SnackBarComponent.propTypes = {
   message: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]),
   handleClose: PropTypes.func.isRequired,
-  isOpen: PropTypes.bool.isRequired,
+  open: PropTypes.bool.isRequired,
 };
 
 SnackBarComponent.defaultProps = {

--- a/app/scss/_SearchResultItem.scss
+++ b/app/scss/_SearchResultItem.scss
@@ -1,4 +1,4 @@
-.searchResultItemRequest, .searchResultItemVisitProfile {
+.searchResultItemRequest {
     width: 45%;
 }
 
@@ -45,6 +45,11 @@
 
 .searchResultItemDetails {
     white-space: unset;
+}
+
+.message-buttons {
+  display: flex;
+  justify-content: space-evenly;
 }
 
 @media (min-width: 750px) {

--- a/app/scss/_SearchResults.scss
+++ b/app/scss/_SearchResults.scss
@@ -55,6 +55,12 @@
     text-decoration: none;
 }
 
+@media (max-width: 480px) {
+  .searchResultItemDetails > p {
+    text-align: left;
+  }
+}
+
 @media (min-width: 501px) {
     .pagination.hideOnMobile {
         display: block;
@@ -65,9 +71,7 @@
     }
 
     .searchResultsContainer {
-        max-width: 90%;
         text-align: center;
-        margin: -24px 0 0 36px;
     }
 
     .searchResultDropdown, .searchResultsHeader {

--- a/app/scss/_SignIn.scss
+++ b/app/scss/_SignIn.scss
@@ -8,6 +8,10 @@
     margin-top: 24px;
 }
 
+.signUpEmailInputField > label {
+  color: #0099ff !important;
+}
+
 @media (max-width: 500px) {
     .signInLink, .signInLinkSecondary {
         margin: 12px 0;

--- a/app/scss/_SignIn.scss
+++ b/app/scss/_SignIn.scss
@@ -8,7 +8,7 @@
     margin-top: 24px;
 }
 
-.signUpEmailInputField > label {
+.signInEmailInputField > label {
   color: #0099ff !important;
 }
 

--- a/app/scss/_UserProfile.scss
+++ b/app/scss/_UserProfile.scss
@@ -21,9 +21,8 @@
 }
 
 .userProfileSendEmail {
-    position: absolute;
-    bottom: -24px;
-    right: 0;
+    float: right;
+    margin-bottom: 5px;
 }
 
 .userProfileBackButton {

--- a/app/scss/_withUserForm.scss
+++ b/app/scss/_withUserForm.scss
@@ -42,6 +42,10 @@
     min-width: 500px;
 }
 
+.userFormInputField > label {
+  color: #0099ff !important;
+}
+
 .userFormImage {
     width: 49%;
     margin: 24px 0;


### PR DESCRIPTION
Fixed css issues such as:

   1.changed labels to a darker blue for forms.
   2.fix "Available Volunteers" title to prevent overlap with nav bar.
   3. Ratings colliding with message buttons.
    4. View Profile button text truncated due to a set width of 45%. Removed width. 

Fixed SnackBar component

  1.Changed mis-matched props from "isOpen" to "open".
  2.Fixed missing "Back to Search Results" button.

Previous refactoring moved the buttons into its own MessageButtons component
which handleViewProfileClick function was not called. Passed into MessageButtons as
props. It now works.
Removed the "if search && search results" conditional in renderBackButton function.
This button only shows in search results for profile view. We always want it to show
since we don't have a volunteers index anyhow that shows all volunteers. We only find
volunteers with the search button so makes sense to always have this for the volunteer
user profile.