### PR TITLE
Fix problems with availabilities that span days in UTC. Improve tests

### DIFF
--- a/spec/contexts/availabilities_creation_spec.rb
+++ b/spec/contexts/availabilities_creation_spec.rb
@@ -1,33 +1,46 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe Contexts::Availabilities::Creation do
+  def timestring(hhmmstr)
+    "Fri Apr 10 2020 #{hhmmstr.strip} CDT -05:00"
+  end
 
-  describe "Availability Creation Initialization" do
+  describe 'Availability Creation Initialization' do
     volunteer = FactoryBot.create(:volunteer_user)
-    it "can be initialized" do
-      expect { 
+
+    it 'can be initialized' do
+      expect do
         Contexts::Availabilities::Creation.new(
-          { day: "Wednesday", start_time: "11:00", end_time: "13:00" },
+          { day: 2,
+            start_time: timestring('11:00:40'),
+            end_time: timestring('13:00:40') },
           volunteer
-        )}.not_to raise_error
+        )
+      end .not_to raise_error
     end
-    it "detects missing start time" do
-      expect { 
+
+    it 'detects missing start time' do
+      expect do
         Contexts::Availabilities::Creation.new(
-          { day: "Wednesday", end_time: "13:00" },
+          { day: 2, end_time: timestring('13:00:40') },
           volunteer
-        )}.to raise_error (Contexts::Availabilities::Errors::StartTimeMissing)
+        )
+      end .to raise_error Contexts::Availabilities::Errors::StartTimeMissing
     end
-    it "detects missing end time" do
-      expect { 
+
+    it 'detects missing end time' do
+      expect do
         Contexts::Availabilities::Creation.new(
-          { day: "Wednesday", start_time: "13:00" },
+          { day: 2, start_time: timestring('13:00:40') },
           volunteer
-        )}.to raise_error (Contexts::Availabilities::Errors::EndTimeMissing)
+        )
+      end .to raise_error Contexts::Availabilities::Errors::EndTimeMissing
     end
-    it "detects missing day of week"
+
+    it 'detects missing day of week'
     # it "detects missing day of week" do
-    #   expect { 
+    #   expect {
     #     Contexts::Availabilities::Creation.new(
     #       { start_time: "13:00", end_time: "14:00" },
     #       volunteer
@@ -35,54 +48,154 @@ describe Contexts::Availabilities::Creation do
     # end
   end
 
-  describe "Availability Creation Execution" do
+  describe 'Availability Creation Execution' do
+    def init_availabilities
+      @availability_times.each_with_index do |availability, _i|
+        avail = Contexts::Availabilities::Creation.new(
+          { day: 6,
+            start_time: availability[:start],
+            end_time: availability[:end] },
+          @volunteer
+        )
+        avail.execute
+      end
+    end
+
     before(:each) do
       @volunteer = FactoryBot.create(:volunteer_user)
-      availability1 = Contexts::Availabilities::Creation.new(
-        { day: "Wednesday", start_time: "11:00", end_time: "13:00" },
-        @volunteer
-      )
-      availability1.execute # 'save' it
+      @availability_times = [
+        { start: timestring('00:00:00'), end: timestring('01:00:40') },
+        { start: timestring('01:00:32'), end: timestring('02:00:48') },
+        # around UTC change of day
+        { start: timestring('18:00:32'), end: timestring('19:00:32') },
+        { start: timestring('19:00:58'), end: timestring('20:00:06') },
+        { start: timestring('02:30:17'), end: timestring('03:45:19') },
+        { start: timestring('05:00:17'), end: timestring('07:00:19') }
+      ]
     end
-    context "overlap checks" do
-      it "creates new availability with no overlap" do
-        availability2 = Contexts::Availabilities::Creation.new(
-          { day: "Wednesday", start_time: "13:00", end_time: "14:00" },
-          @volunteer
-        )
-        expect {availability2.execute}.not_to raise_error          
+
+    context 'overlap checks' do
+      it 'creates new availability with no overlap' do
+        @availability_times.each do |availability|
+          test_availability = Contexts::Availabilities::Creation.new(
+            { day: 6,
+              start_time: availability[:start],
+              end_time: availability[:end] },
+            @volunteer
+          )
+          expect { test_availability.execute }.not_to raise_error
+        end
       end
-      it "detects if start time in existing overlap" do
-        availability2 = Contexts::Availabilities::Creation.new(
-          { day: "Wednesday", start_time: "12:00", end_time: "14:00" },
-          @volunteer
-        )
-        expect {availability2.execute}.to raise_error (Contexts::Availabilities::Errors::OverlappingAvailability)  
+
+      it 'detects if overlaps with existing start times' do
+        init_availabilities
+        new_availabilities = [
+          { start: timestring('00:59:17'), end: timestring('02:00:19') },
+          { start: timestring('17:45:17'), end: timestring('18:30:19') },
+          { start: timestring('18:59:17'), end: timestring('20:00:19') },
+          { start: timestring('00:01:17'), end: timestring('23:59:19') }
+        ]
+        new_availabilities.each do |availability|
+          test_availability = Contexts::Availabilities::Creation.new(
+            { day: 6,
+              start_time: availability[:start],
+              end_time: availability[:end] },
+            @volunteer
+          )
+          expect { test_availability.execute }.to raise_error Contexts::Availabilities::Errors::OverlappingAvailability
+        end
       end
-      it "detects if end time in existing overlap" do
-        availability2 = Contexts::Availabilities::Creation.new(
-          { day: "Wednesday", start_time: "10:00", end_time: "12:00" },
-          @volunteer
-        )
-        expect {availability2.execute}.to raise_error (Contexts::Availabilities::Errors::OverlappingAvailability)  
+
+      it 'detects if end time in existing overlap' do
+        init_availabilities
+        new_availabilities = [
+          { start: timestring('00:00:17'), end: timestring('01:01:19') },
+          { start: timestring('18:00:17'), end: timestring('18:31:19') },
+          { start: timestring('17:00:17'), end: timestring('18:01:19') },
+          { start: timestring('01:00:17'), end: timestring('02:02:19') }
+        ]
+        new_availabilities.each do |availability|
+          test_availability = Contexts::Availabilities::Creation.new(
+            { day: 6,
+              start_time: availability[:start],
+              end_time: availability[:end] },
+            @volunteer
+          )
+          expect { test_availability.execute }.to raise_error Contexts::Availabilities::Errors::OverlappingAvailability
+        end
       end
-      it "detects if it contains existing availability" do
-        availability2 = Contexts::Availabilities::Creation.new(
-          { day: "Wednesday", start_time: "10:00", end_time: "15:00" },
-          @volunteer
-        )
-        expect {availability2.execute}.to raise_error (Contexts::Availabilities::Errors::OverlappingAvailability)  
+
+      it 'detects if it contains existing availability' do
+        init_availabilities
+        new_availabilities = [
+          { start: timestring('00:01:17'), end: timestring('00:41:19') },
+          { start: timestring('18:00:17'), end: timestring('18:31:19') },
+          { start: timestring('18:01:17'), end: timestring('18:45:19') }
+        ]
+        new_availabilities.each do |availability|
+          test_availability = Contexts::Availabilities::Creation.new(
+            { day: 6,
+              start_time: availability[:start],
+              end_time: availability[:end] },
+            @volunteer
+          )
+          expect { test_availability.execute }.to raise_error Contexts::Availabilities::Errors::OverlappingAvailability
+        end
       end
     end
 
-     context "minimum time period" do
-       it "detects availabilities less than 30 minutes"
-       it "detects correct time period with day spans"
-     end
+    context 'minimum time period' do
+      it 'detects availabilities less than 30 minutes' do
+        short_availabilities = [
+          { start: timestring('17:45:17'), end: timestring('18:10:19') },
+          { start: timestring('00:00:17'), end: timestring('00:01:19') },
+          { start: timestring('23:30:17'), end: timestring('23:59:19') }
+        ]
+        short_availabilities.each do |availability|
+          test_availability = Contexts::Availabilities::Creation.new(
+            { day: 6,
+              start_time: availability[:start],
+              end_time: availability[:end] },
+            @volunteer
+          )
+          expect { test_availability.execute }.to raise_error Contexts::Availabilities::Errors::ShortAvailability
+        end
+      end
 
-     context "starts before it ends" do
-       it "detects ends before starts" 
-       it "detects end before start with day spans"
-     end
+      it 'allow availabilities of 30 minutes' do
+        good_availabilities = [
+          { start: timestring('17:45:17'), end: timestring('18:15:19') },
+          { start: timestring('00:00:17'), end: timestring('00:31:19') }
+        ]
+        good_availabilities.each do |availability|
+          test_availability = Contexts::Availabilities::Creation.new(
+            { day: 6,
+              start_time: availability[:start],
+              end_time: availability[:end] },
+            @volunteer
+          )
+          expect { test_availability.execute }.not_to raise_error
+        end
+      end
+    end
+
+    context 'starts before it ends' do
+      it 'detects ends before starts' do
+        bad_availabilities = [
+          { start: timestring('18:01:17'), end: timestring('17:30:19') },
+          { start: timestring('01:00:17'), end: timestring('00:00:19') },
+          { start: timestring('23:59:17'), end: timestring('00:00:19') }
+        ]
+        bad_availabilities.each do |availability|
+          test_availability = Contexts::Availabilities::Creation.new(
+            { day: 6,
+              start_time: availability[:start],
+              end_time: availability[:end] },
+            @volunteer
+          )
+          expect { test_availability.execute }.to raise_error Contexts::Availabilities::Errors::ShortAvailability
+        end
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     url_slug
     active { true }
     terms_and_conditions { true }
-    timezone { 'UTC' }
+    timezone { 'Central Time (US & Canada)' }
     # programs = []
     # programs << FactoryBot.create(:program)
     # programs { programs }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to include("You have successfully signed up to domainname as a volunteer")
+      expect(mail.body.encoded).to include("You have successfully created a volunteer account on domainname")
     end
   end
   describe 'When a user receives a new email' do


### PR DESCRIPTION
Trello card is "false positives for 30 minute minimum availability check".  But changes may also fix some other timezone problems.  Cause of errors was related to trying to figure out if availability start/stop spanned a day in UTC time.

Summary of changes:
- in context for availability creation, use start/stop times in user timezone for validity checks. (because in user timezone, availability cannot span a day).
- add/improve availability rspec tests.  Note: also cleaned up a minor test failure with the user mailer spec.
