### PR TITLE
added locale to mailers to fix reset password bug.

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', password_edit_url(user: @resource, reset_password_token: @token) %></p>
+<p><%= link_to 'Change my password', password_edit_url(user: @resource, reset_password_token: @token, locale: @resource.locale) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token, locale: @resource.locale) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.default_options = { from: 'noreply@tutoria.io' }
 end


### PR DESCRIPTION
-Currently, resetting the password sends out an email with a link to reset the password. The link goes to a 404 oops page since the locale is missing from the path.
-Added locale to the path.
-Added default mailer in evironments for testing in development.  