### PR TITLE
Fix for incomplete signup form when using mini form on homepage

### DIFF
--- a/app/javascript/components/Homepage.js
+++ b/app/javascript/components/Homepage.js
@@ -34,9 +34,6 @@ import {
   // Grid,
   // ButtonGroup
 } from '@material-ui/core';
-// import {
-//   Link
-// } from 'react-router-dom';
 import validate from 'react-joi-validation';
 import PropTypes from 'prop-types';
 
@@ -175,7 +172,6 @@ class Homepage extends Component {
     const { locale } = this.props;
 
     this.state = {
-      // languageChecked: ENGLISH,
       languageChecked: locale,
       signUpType: 'client',
       // mapView: 'row',
@@ -633,23 +629,12 @@ class Homepage extends Component {
           <Fab
             className='submitButton'
             variant='extended'
-            // component={ Link }
             component='button'
             disabled={ !_.isEmpty(errors) }
             href={ formatLink(
               '/sign_up/'+this.state.signUpType, this.state.languageChecked
              ) }
-            // to={ {
-            //   pathname: formatLink('/sign_up/'+this.state.signUpType, this.state.languageChecked),
-            //   state: {
-            //     currentUser: {
-            //       first_name: this.props.first_name,
-            //       email: this.props.email
-            //     }
-            //   }
-            // } }
-            onClick={ (/*event*/) => { 
-              // this.handleScroll(event, 0); 
+            onClick={ () => { 
               SignUpSession.saveSession(
                 this.props.first_name,
                 this.props.email,

--- a/app/javascript/components/Homepage.js
+++ b/app/javascript/components/Homepage.js
@@ -34,9 +34,9 @@ import {
   // Grid,
   // ButtonGroup
 } from '@material-ui/core';
-import {
-  Link
-} from 'react-router-dom';
+// import {
+//   Link
+// } from 'react-router-dom';
 import validate from 'react-joi-validation';
 import PropTypes from 'prop-types';
 
@@ -47,6 +47,7 @@ import {
   SPANISH
 } from './utils/availableLocales';
 import formatLink from './utils/Link';
+import SignUpSession from './utils/SignUpSession';
 import SignUpSchema from './schema/SignUpSchema';
 import contactInfo from '../ContactInfo';
 // import UserMap from './UserMap';
@@ -170,9 +171,12 @@ class Homepage extends Component {
     this.handleUserToggle = this.handleUserToggle.bind(this);
 
     this.joinUsFormRef = React.createRef();
+    
+    const { locale } = this.props;
 
     this.state = {
-      languageChecked: ENGLISH,
+      // languageChecked: ENGLISH,
+      languageChecked: locale,
       signUpType: 'client',
       // mapView: 'row',
       // clientsSelected: true,
@@ -629,19 +633,28 @@ class Homepage extends Component {
           <Fab
             className='submitButton'
             variant='extended'
-            component={ Link }
+            // component={ Link }
+            component='button'
             disabled={ !_.isEmpty(errors) }
-            to={ {
-              pathname: formatLink('/sign_up/'+this.state.signUpType, this.state.languageChecked),
-              state: {
-                currentUser: {
-                  first_name: this.props.first_name,
-                  email: this.props.email
-                }
-              }
-            } }
-            onClick={ (event) => { 
-              this.handleScroll(event, 0); 
+            href={ formatLink(
+              '/sign_up/'+this.state.signUpType, this.state.languageChecked
+             ) }
+            // to={ {
+            //   pathname: formatLink('/sign_up/'+this.state.signUpType, this.state.languageChecked),
+            //   state: {
+            //     currentUser: {
+            //       first_name: this.props.first_name,
+            //       email: this.props.email
+            //     }
+            //   }
+            // } }
+            onClick={ (/*event*/) => { 
+              // this.handleScroll(event, 0); 
+              SignUpSession.saveSession(
+                this.props.first_name,
+                this.props.email,
+                this.state.languageChecked
+              );
               gtag_formsent_conversion(locale === 'en' ? opts.joinus_en : opts.joinus_es);
               gtag_formsent_conversion(locale === 'en' ? opts.signform_en : opts.signform_es);
             } }

--- a/app/javascript/components/SignUp.js
+++ b/app/javascript/components/SignUp.js
@@ -8,6 +8,7 @@ import UserFormConstants from './utils/UserFormConstants';
 import SignUpSchema from './schema/SignUpSchema';
 import { postData } from './utils/sendData';
 import formatLink from './utils/Link';
+import SignUpSession from './utils/SignUpSession';
 import PageHeader from './reusable/PageHeader';
 import { gtag_formsent_conversion, opts } from './reusable/tracking';
 
@@ -66,6 +67,23 @@ function handleUserSignUp() {
 }
 
 class SignUp extends Component {
+  constructor(props) {
+    super(props);
+
+    this.clearSignUpSession = this.clearSignUpSession.bind(this);
+  }
+  clearSignUpSession() {
+    if(SignUpSession.sessionExists()) {
+      SignUpSession.clearSession();
+    }
+  }
+  componentDidMount() {
+    // Clear any sign up session data if the user leaves the sign up page
+    window.addEventListener('beforeunload', this.clearSignUpSession);
+  }
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.clearSignUpSession);
+  }
   
   render() {
     return (
@@ -75,7 +93,7 @@ class SignUp extends Component {
             id='SignUp.signUpHeader'
             defaultMessage='Join Tutoría community: Step 1/2'
            />
-         ) }
+          ) }
          />
       </div>
     );
@@ -83,6 +101,11 @@ class SignUp extends Component {
 }
 
 const extraProps =  { type: SIGN_UP, primaryButtonAction: handleUserSignUp, primaryButtonLabel:'Next Step (2/2)' };
+
+if(SignUpSession.sessionExists()) {
+  extraProps.userData = SignUpSession.getSession();
+}
+
 
 export default withUserForm(SignUp, SignUpSchema, extraProps);
 

--- a/app/javascript/components/reusable/withUserForm.js
+++ b/app/javascript/components/reusable/withUserForm.js
@@ -62,8 +62,29 @@ const withUserForm = (WrappedComponent, schema, wrappedProps) => {
         user: props.currentUser
       };
 
+      const { location, changeValues } = this.props;   
+ 
+      // If the location.state contains a user data, then restore the values to the form
+      if(!_.isEmpty(location.state)) {
+        changeValues(
+          ['first_name', location.state.currentUser.first_name],
+          ['email', location.state.currentUser.email],
+        );        
+      }else if(wrappedProps && 'userData' in wrappedProps) {
+        //If there is data to show in the form for this user, restore the values to the form
+        const userData = wrappedProps['userData'];
+        changeValues( 
+          [
+            ['first_name', userData.firstName],
+            ['email', userData.email],
+            ['locale', userData.locale]
+          ] 
+        );
+      }
+     
       this.sortArrayProps(props);
     }
+    
 
     render() {
       const {
@@ -83,7 +104,6 @@ const withUserForm = (WrappedComponent, schema, wrappedProps) => {
         },
         currentUser,
         timezones,
-        location,
       } = this.props;
 
       return (
@@ -109,7 +129,7 @@ const withUserForm = (WrappedComponent, schema, wrappedProps) => {
 
               <TextField
                 name='email'
-                value={ _.isEmpty(location.state) ? email : location.state.currentUser.email }
+                value={ email }
                 className='userFormInputField email'
                 hintText=''
                 floatingLabelText={
@@ -151,7 +171,7 @@ const withUserForm = (WrappedComponent, schema, wrappedProps) => {
 
               <TextField
                 name='first_name'
-                value={ _.isEmpty(location.state) ? first_name : location.state.currentUser.first_name }
+                value={ first_name }
                 hintText=''
                 className='userFormInputField firstName'
                 floatingLabelText={

--- a/app/javascript/components/utils/SignUpSession.js
+++ b/app/javascript/components/utils/SignUpSession.js
@@ -1,0 +1,39 @@
+
+const FIRST_NAME = 'newSignUpFirstName';
+const EMAIL = 'newSignUpEmail';
+const LOCALE = 'newSignUpLocale';
+
+class SignUpSession {
+    static saveSession(firstName, email, locale) {
+        sessionStorage.setItem(FIRST_NAME,firstName);
+        sessionStorage.setItem(EMAIL, email);
+        sessionStorage.setItem(LOCALE, locale);   
+    }
+    static sessionExists() {
+        if (FIRST_NAME in sessionStorage)
+            return true;
+        else if (EMAIL in sessionStorage)
+            return true;
+        else if (LOCALE in sessionStorage)
+            return true;
+        else
+            return false;
+    }
+    static getSession() {
+        let sessionObj = {};
+
+        sessionObj.firstName = (FIRST_NAME in sessionStorage) ? sessionStorage.getItem(FIRST_NAME) : '';
+        sessionObj.email = (EMAIL in sessionStorage) ? sessionStorage.getItem(EMAIL) : '';
+        sessionObj.locale = (LOCALE in sessionStorage) ? sessionStorage.getItem(LOCALE) : '';
+
+        return sessionObj;
+    }    
+    static clearSession() {
+        sessionStorage.removeItem(FIRST_NAME);
+        sessionStorage.removeItem(EMAIL);
+        sessionStorage.removeItem(LOCALE);   
+    }
+    
+}
+
+export default SignUpSession;


### PR DESCRIPTION
Workaround for the incomplete signup form when using the mini form on the home page due to the Link request not going through the ruby server to get all of the form data.

-  Switched to using sessionStorage and button component to have the request go through the ruby server and get the missing data. The data in session storage will also be cleared if the user reloads or navigates to another page in the same window. Previously used Link component and passed state (first name and email) within the Link component. 
- First name and email can still be passed in a Link component's state and the values will be editable.
- Full sign up form now restores the selected preferred language, along with the email and first name.
- Mini form now selects the user's current locale, instead of always selecting English.
- Transferred data (first name, email, and preferred language) can be modified when the sign up form loads. Previously did not allow the transferred email and first name fields to be modified in the user interface, but the fields remained enabled.
