### PR TITLE
Fixed blank dropdown on New client Signup and days changing from user selection.

### DIFF
--- a/app/javascript/components/SearchBar.js
+++ b/app/javascript/components/SearchBar.js
@@ -33,7 +33,7 @@ class SearchBar extends Component {
     this.state = {
       error: '',
       status: 0,
-      showSnackBar: false
+      showSnackBar: false,
     };
   }
 
@@ -132,7 +132,7 @@ class SearchBar extends Component {
       location: { state },
       validateAllHandler
     } = this.props;
-
+  
     return (
       <div>
         { this.renderTitle() }
@@ -316,14 +316,15 @@ class SearchBar extends Component {
   }
 
   selectionRendererDay(values) {
-    const { days } = this.props;
-
+    const { days, location: { state } } = this.props;
+    const allDays = days.length > 0 ? days : state.days;
+     
     if (_.size(values) > 1) {
       return _.trimEnd(_.map(values, (value) => {
-        return days[value];
-      }).join(', '), ', ');
+        return allDays[value];
+      }).join(', '), ', '); 
     } else if (_.size(values) === 1) {
-      return days[values];
+      return allDays[values];
     }
   }
 


### PR DESCRIPTION
-When users first signup and are sent to /search, days is an empty array so nothing is displayed. Since users are coming from a history.push with location state after signup, I used the days in state object. 