### PR TITLE
Mobile Usability Error Fixes

### DIFF
--- a/app/javascript/components/reusable/Footer.js
+++ b/app/javascript/components/reusable/Footer.js
@@ -53,111 +53,117 @@ class Footer extends Component {
           </span>
         </h3>
         <span className='footerBody'>
-          <span className='footerLinks'>
-            <b>
-              <FormattedMessage
-                id='Footer.usefulLinks'
-                defaultMessage='Useful Links'
-              />
-            </b>
-            <a href={ formatLink('/about', locale) }>
-              <FormattedMessage
-                id='aboutPage'
-                defaultMessage='About'
-              />
-            </a>
-            <a href={ formatLink('/faq', locale) }>
-              <FormattedMessage
-                id='FAQPage'
-                defaultMessage='FAQ'
-              />
-            </a>
-            <a href={ formatLink('/terms_of_use', locale) }>
-              <FormattedMessage
-                id='Footer.TAC'
-                defaultMessage='Terms & Conditions'
-              />
-            </a>
-          </span>
-          <span className='socialMediaLinks'>
-            <b>
-              <FormattedMessage
-                id='Footer.socialMedia'
-                defaultMessage='Social Media'
-              />
-            </b>
-            <a 
-              href={ contactInfo.FACEBOOK }
-              rel='noopener noreferrer' 
-              target='_blank'
-            >
-              <FaFacebookF
-                size={ size }
-                className='facebookIcon'
-              />
-              Facebook
-            </a>
-            <a 
-              href={ contactInfo.LINKEDIN }  
-              rel='noopener noreferrer' 
-              target='_blank'
-            >
-              <FaLinkedin
-                size={ size }
-                className='linkedInIcon'
-              />
-              LinkedIn
-            </a>
-          </span>
-          <span className='footerAddress'>
-            <b>
-              <FormattedMessage
-                id='Footer.address'
-                defaultMessage='Address'
-              />
-            </b>
-            { 
-              '495a Henry Street #1020,\n'+
-              'Brooklyn, NY, 11231,\n'+
-              'United States of America'
-            }
-          </span>
-          <span className='footerContact'>
-            <b>
-              <FormattedMessage
-                id='Footer.contact'
-                defaultMessage='Contact Us'
-              />
-            </b>
-            <a
-              href={ 'tel:'+contactInfo.PHONE }
-            >
-              <FaPhone
-                size={ size }
-                label={ (
-                  <FormattedMessage
-                    id="UserForm.phoneNumber"
-                    defaultMessage="Phone Number"
-                  />
-                ) }
-              />
-              { ' '+contactInfo.PHONE }
-            </a>
-            <a
-              href={ 'mailto:'+contactInfo.EMAIL }
-            >
-              <FaEnvelope
-                size={ size }
-                label={ (
-                  <FormattedMessage
-                    id="UserForm.email"
-                    defaultMessage="Email address"
-                  />
-                ) }
-              />
-              { ' '+contactInfo.EMAIL }
-            </a>
-          </span>
+          <div>
+            <span className='footerLinks'>
+              <b>
+                <FormattedMessage
+                  id='Footer.usefulLinks'
+                  defaultMessage='Useful Links'
+                />
+              </b>
+              <a href={ formatLink('/about', locale) }>
+                <FormattedMessage
+                  id='aboutPage'
+                  defaultMessage='About'
+                />
+              </a>
+              <a href={ formatLink('/faq', locale) }>
+                <FormattedMessage
+                  id='FAQPage'
+                  defaultMessage='FAQ'
+                />
+              </a>
+              <a href={ formatLink('/terms_of_use', locale) }>
+                <FormattedMessage
+                  id='Footer.TAC'
+                  defaultMessage='Terms & Conditions'
+                />
+              </a>
+            </span>
+            <span className='socialMediaLinks'>
+              <b>
+                <FormattedMessage
+                  id='Footer.socialMedia'
+                  defaultMessage='Social Media'
+                />
+              </b>
+              <a 
+                href={ contactInfo.FACEBOOK }
+                rel='noopener noreferrer' 
+                target='_blank'
+              >
+                <FaFacebookF
+                  size={ size }
+                  className='facebookIcon'
+                />
+                Facebook
+              </a>
+              <a 
+                href={ contactInfo.LINKEDIN }  
+                rel='noopener noreferrer' 
+                target='_blank'
+              >
+                <FaLinkedin
+                  size={ size }
+                  className='linkedInIcon'
+                />
+                LinkedIn
+              </a>
+            </span>
+          </div>
+          <div>
+            <span className='footerAddress'>
+              <b>
+                <FormattedMessage
+                  id='Footer.address'
+                  defaultMessage='Address'
+                />
+              </b>
+              <p>
+                { 
+                  '495a Henry Street #1020,\n'+
+                  'Brooklyn, NY, 11231,\n'+
+                  'United States of America'
+                }
+              </p>
+            </span>
+            <span className='footerContact'>
+              <b>
+                <FormattedMessage
+                  id='Footer.contact'
+                  defaultMessage='Contact Us'
+                />
+              </b>
+              <a
+                href={ 'tel:'+contactInfo.PHONE }
+              >
+                <FaPhone
+                  size={ size }
+                  label={ (
+                    <FormattedMessage
+                      id="UserForm.phoneNumber"
+                      defaultMessage="Phone Number"
+                    />
+                  ) }
+                />
+                { ' '+contactInfo.PHONE }
+              </a>
+              <a
+                href={ 'mailto:'+contactInfo.EMAIL }
+              >
+                <FaEnvelope
+                  size={ size }
+                  label={ (
+                    <FormattedMessage
+                      id="UserForm.email"
+                      defaultMessage="Email address"
+                    />
+                  ) }
+                />
+                { ' '+contactInfo.EMAIL }
+              </a>
+            </span>
+          </div>
         </span>
       </span>
     );

--- a/app/javascript/components/reusable/Header.js
+++ b/app/javascript/components/reusable/Header.js
@@ -175,14 +175,10 @@ class Header extends Component {
             <Toolbar
               classes={ { root: 'menuAppBarLower' } }
             >
-              <span
-                classes={ { root: 'menuAppBarLowerLeftElements' } }
-              >
+              <span className='menuAppBarLowerLeftElements'>
                 { this.renderHomeButton() }
               </span>
-              <span
-                classes={ { root: 'menuAppBarLowerRightElements' } }
-              >
+              <span className='menuAppBarLowerRightElements'>
                 { this.renderRightElements() }
               </span>
             </Toolbar>

--- a/app/scss/_Footer.scss
+++ b/app/scss/_Footer.scss
@@ -34,11 +34,21 @@
     display: inline-flex;
 }
 
-.footerBody > span {
+.footerBody > div > span {
     display: flex;
     flex-flow: column;
     padding-right: 2pc;
     padding-left: 2pc;
+}
+
+.footerBody > div {
+    display: flex;
+    flex-flow: row nowrap;
+}
+
+.footerBody > div > span > p {
+    text-align: left;
+    margin: 0;
 }
 
 .copyrightAndLogo {
@@ -59,6 +69,29 @@
     padding-left: .2pc;
 }
 
+@media (max-width: 1130px) {
+    .footerBody {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .footerBody > div { 
+        flex-flow: column wrap;
+    }
+    
+    .footerBody > div:last-child {
+        text-align: right;
+    }
+
+    .footerBody > div > span {
+        padding: 1em 2em;
+    }
+
+    .leftElementsContainer {
+        flex-grow: 1;
+    }
+}
+
 @media (max-width: 901px) {
     .footerToolbar {
         flex-flow: column;
@@ -73,17 +106,35 @@
         width: 100%;
     }
 
-    .footerBody {
-        display: grid;
-        grid-template-columns: 50% 50%;
-        font-size: small;
-    }
-
-    .footerBody > span > a {
-        font-size: x-small;
-    }
-
     .footerBody > span {
         padding: none;
+    }
+
+    .footerBody > div > span > b {
+        font-size: 1.4em;
+        padding-bottom: 0.2em;
+    }
+
+    .footerBody > div > span > a,
+    .footerBody > div > span > p {
+       font-size: 1.2em;
+       padding-top: 0.5em;
+       padding-bottom: 0.5em;
+    }
+
+}
+
+@media (max-width: 560px) {
+    .footerBody {
+        flex-flow: column nowrap;
+    }
+
+    .footerBody > div:last-child {
+        text-align: left;
+    }
+
+    .footerBody > div > span {
+        padding-right: 0;
+        padding-left: 1em;
     }
 }

--- a/app/scss/_Header.scss
+++ b/app/scss/_Header.scss
@@ -25,6 +25,9 @@
 .signedOutHeader {
     display: flex;
 }
+.signedOutHeader > span {
+    margin: auto;
+}
 
 .roleLinks > span {
     display: flex;
@@ -62,6 +65,17 @@
 
 .signedInHeader {
     display: flex;
+}
+
+@media (max-width: 1130px) {
+    .menuAppBarLower {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .rightElements {
+        min-height: 5em;
+    }
 }
 
 // Window.width < 900px Styles

--- a/app/scss/_Homepage.scss
+++ b/app/scss/_Homepage.scss
@@ -18,15 +18,15 @@ p {
 }
 
 .splashObjects {
-    margin-left: 10pc;
-    margin-right: 10pc;
+    margin-left: 10%;
+    margin-right: 10%;
     display: flex;
     flex-flow: row;
 }
 
 .testimonialsContainer {
-    margin-top: 3pc;
-    margin-bottom: 3pc;
+    margin-top: 4em;
+    margin-bottom: 4em;
 }
 
 .testimonialsSubtitle {
@@ -43,19 +43,23 @@ p {
     font-weight: bold;
     font-family: 'Lato';
     font-size: 18px;
-    align-self: baseline;
 }
 
 .homepageContact {
     display: flex;
-    padding-bottom: 2pc;
+    padding-bottom: 2em;
+}
+
+.homepageContact > span {
+    margin-top: 2em;
+    margin-bottom: 2em;
 }
 
 .featuredProgramsContainer {
-    margin-left: 10pc;
-    margin-right: 10pc;
-    margin-top: 3pc;
-    margin-bottom: 3pc;
+    margin-left: 10%;
+    margin-right: 10%;
+    margin-top: 3em;
+    margin-bottom: 3em;
     text-align: center;
 }
 
@@ -68,15 +72,15 @@ p {
 }
 
 .featuredProgramsContentContainer  > div {
-    padding: 2pc;
-    min-width: 20pc;
-    max-width: 20vw;
+    display: flex;
+    padding: 3em 3%;
+    width: 30%;
 }
 
 .featuredProgramsContentContainer > div > div {
     background-color: #004664;
     color: white;
-    padding: 1pc;
+    padding: 1em;
 }
 
 .featuredProgramsContentContainer > div > div > div {
@@ -95,8 +99,8 @@ p {
 }
 
 .howItWorksContainer {
-    margin-top: 3pc;
-    margin-bottom: 3pc;
+    margin-top: 4em;
+    margin-bottom: 4em;
     align-items: center;
     display: flex;
     flex-flow: column;
@@ -107,30 +111,25 @@ p {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    width: 80pc;
+    width: 80%;
+}
+
+.howItWorksContentContainer > div{
+    width: 35%;
+    display: flex;
+    flex-grow: 1;
+    margin: 3%;
 }
 
 .howItWorksContentContainer > div > div {
-    margin: 1pc;
-    width: 35pc;
-    height: 13pc;
-    justify-content: center;
     box-shadow: none;
     background-color: #FAFAFA;
 }
 
-.howItWorksContentContainer > div > div > div {
-    display: flex;
-    flex-flow: column;
-    height: stretch;
-    align-items: center;
-}
-
 .cardContent {
-    height: stretch;
     display: flex;
     align-content: center;
-    width: 20pc;
+    justify-content: flex-end;
 }
 
 .cardTextSpan {
@@ -179,8 +178,9 @@ p {
 }
 
 .joinUsContainer {
-    margin-top: 3pc;
-    margin-bottom: 3pc;
+    width: 100%;
+    margin-top: 3em;
+    margin-bottom: 3em;
     display: flex;
     flex-flow: column;
     align-items: center;
@@ -197,15 +197,15 @@ p {
 
 .joinUsForm {
     background-color: white;
-    width: 40pc;
-    padding: 5pc;
-    padding-bottom: 2pc;
-    margin: 2pc;
+    width: 50vw;
+    padding: 5em;
+    padding-bottom: 2em;
+    margin: 2em;
 }
 
 .joinUsForm > div {
-    margin-bottom: 2pc;
-    margin-top: 2pc;
+    margin-bottom: 2em;
+    margin-top: 2em;
 }
 
 .joinUsForm > div > div > input {
@@ -286,14 +286,13 @@ p {
 
 .splashContainer > button,
 .submitButtonContainer > a {
+    height: auto;
     text-transform: none;
     background-color: #004664;
     color: white;
-    text-transform: none;
     font-family: 'Lato';
     font-size: 18px;
-    padding-right: 3pc;
-    padding-left: 3pc;
+    padding: 0.5em 2em;
 }
 
 .splashContainer > button:hover,
@@ -304,6 +303,7 @@ p {
 .submitButtonContainer {
     display: flex;
     justify-content: center; 
+    text-align: center;
 }
 
 .needHelpContainer {
@@ -369,10 +369,6 @@ p {
         display: block;
     }
 
-    .testimonialsContainer {
-        height: 60vh
-    }
-
     .splashContainer .homepageContact,
     .splashObjects {
         flex-flow: column;
@@ -383,22 +379,51 @@ p {
         margin: auto;
     }
 
-    .howItWorksContentContainer {
+    .featuredProgramsContentContainer {
         flex-flow: column;
         align-items: center;
     }
 
+    .featuredProgramsContentContainer > div {
+        width: 80%;
+    }
+
+    .howItWorksContentContainer {
+        flex-flow: column;
+        align-items: center;
+    }
+    
+    .howItWorksContentContainer > div{
+        width: 95%;
+        justify-content: center;
+    }
+    .joinUsContainer {
+        width: 100%;
+    }
     .joinUsContentContainer {
-        width: stretch;
+        width: 100%;
     }
     
     .joinUsForm {
-        width: inherit;
+         width: 80%;
         padding: 1pc;
+    }
+
+    .joinUsSubtitle {
+        margin-left: 1em;
+        margin-right: 1em;
     }
 
     .needHelpLinks .homepageContact {
         flex-flow: column;
         justify-content: space-between;
     }
+}
+
+@media (max-width: 500px) {
+
+    .radioButtons > div {
+        flex-flow: column;
+    }
+
 }

--- a/app/scss/_TestimonialsCarousel.scss
+++ b/app/scss/_TestimonialsCarousel.scss
@@ -1,7 +1,7 @@
 @import '~video-react/styles/scss/video-react';
 
-$card_width: 20pc;
-$card_media_height: 20pc;
+$card_width: 18pc;
+$card_media_height: 22pc;
 $media_padding: 2pc;
 
 .cardCarouselContainer {
@@ -60,6 +60,7 @@ $media_padding: 2pc;
     position: absolute;
     top: -($card_media_height);
     text-align: center;
+    overflow: auto;
 }
 
 .cardCarouselMediaQuote > p {
@@ -89,7 +90,7 @@ $media_padding: 2pc;
     color: #004664;
 }
 
-@media (max-width: 901px) {
+@media (max-width: 920px) {
     $mobile_card_width: 13pc;
     $mobile_card_media_height: 15pc;
     $mobile_media_padding:1pc;
@@ -98,6 +99,11 @@ $media_padding: 2pc;
     .cardCarouselContainer {
         padding-left: $mobile_media_padding;
         padding-right: $mobile_media_padding;
+        height: auto;
+    }
+
+    .cardCarouselContainer > div:first-child {
+        position: static;
     }
 
     .cardCarouselContainer > div {
@@ -117,6 +123,49 @@ $media_padding: 2pc;
     }
 
     .cardCarouselMediaQuote {
+        top: -($mobile_card_media_height + 5.1);
+        font-size: $mobile_font_size;
+        width: ($mobile_card_width)-($mobile_media_padding*2);
+        height: ($mobile_card_media_height)-($mobile_media_padding*2);
+        padding: $mobile_media_padding;
+        transform: translateY(($mobile_card_media_height/2)-($mobile_media_padding*2)-($mobile_font_size/2))
+    }
+}
+
+@media (max-width: 350px) {
+    $mobile_card_width: 8pc;
+    $mobile_card_media_height: 15pc;
+    $mobile_media_padding:1pc;
+    $mobile_font_size: 12px;
+
+    .cardCarouselContainer {
+        padding-left: $mobile_media_padding;
+        padding-right: $mobile_media_padding;
+        height: auto;
+    }
+
+    .cardCarouselContainer > div:first-child {
+        width: $mobile_card_width;
+    }
+
+    .cardCarouselContainer > div {
+        width: $mobile_card_width;
+    }
+
+    .cardCarouselMedia {
+        height: $mobile_card_media_height;
+    }
+    
+    .cardCarouselMediaPlayer {
+        height: $mobile_card_media_height;
+    }
+
+    .caardCarouselVideoContainer > .cardCarouselContent {
+        padding: 4px; 
+    }
+
+    .cardCarouselMediaQuote {
+        top: -($mobile_card_media_height + 5.1);
         font-size: $mobile_font_size;
         width: ($mobile_card_width)-($mobile_media_padding*2);
         height: ($mobile_card_media_height)-($mobile_media_padding*2);


### PR DESCRIPTION
The 2 errors for mobile usability (1. content wider than window width and 2. tap targets too small) have been fixed and I have modified the CSS for the homepage, footer, and header overall to better support smaller screen sizes by fixing some issues I noticed. 
 

Details: 

Header changes: For screen widths between ~1200px and when the mobile menu appears, the header is wider than the window and users need to scroll sideways to see the right side of the header (e.g. the "Donate" button). To make more room, I moved the logo above the navigation menu for this size range. Also, made the link options in the navigation  centered in the navbar when the links were longer than one line.

Homepage changes: Modified the CSS of most of the content sections to make their width match the screen's width. This includes The testimonial carousel was modified to not block the "Featured Programs" section in landscape mode. The testimonial's quote content was cut off on mobile view, so I made the quote containers scrollable. Also, the text in the "Sign Up" button on the homepage was not centered in the button.

Footer changes: To address the tap targets being too small, I enlarged the text, increased the space between the links, and positioned elements in a single column instead of 2 columns.

Tested on Windows 10 Chrome (4K monitor) and Samsung S9 Chrome