### PR TITLE
Fix for footer positioning

### DIFF
--- a/app/javascript/components/ContentWrapper.js
+++ b/app/javascript/components/ContentWrapper.js
@@ -11,12 +11,9 @@ class ContentWrapper extends Component {
     constructor(props) {
         super(props);
 
-        this.setContentHeight = this.setContentHeight.bind(this);
         this.updateWindowDimensions = this.updateWindowDimensions.bind(this);
-        this.calculateFooterPosition = this.calculateFooterPosition.bind(this);
 
         this.state = {
-            contentHeight: 0,
             mobile: false,
         };
     }
@@ -24,7 +21,6 @@ class ContentWrapper extends Component {
     componentDidMount() {
         this.updateWindowDimensions();
         window.addEventListener('resize', this.updateWindowDimensions);
-        this.setState({ contentHeight: this.pagecontent.offsetHeight });
     }
       
     componentWillUnmount() {
@@ -34,31 +30,15 @@ class ContentWrapper extends Component {
     componentDidUpdate(prevProps) {
         if(this.props.location !== prevProps.location) {
             this.updateWindowDimensions();
-            this.setContentHeight();
         }
     }
-
-    setContentHeight() {
-        this.setState({ contentHeight: this.pagecontent.offsetHeight });
-    }
-    
+  
     updateWindowDimensions() {
     if (window.innerWidth < 900) {
         this.setState({ mobile: true });
     } else {
         this.setState({ mobile: false });
     }
-    }
-
-    calculateFooterPosition() {
-        return(
-            this.state.contentHeight < (0.4*window.innerHeight)
-            && !this.state.mobile
-            ?
-            'absolute'
-            :
-            'relative'
-        );
     }
 
     render () {
@@ -69,13 +49,10 @@ class ContentWrapper extends Component {
         return (
           <div className='pageWrapper'>
             <Header currentUser={ this.props.currentUser } mobile={ this.state.mobile } locale={ this.props.locale } />
-            <div
-              className='pageContent'
-              ref={ (pagecontent) => this.pagecontent = pagecontent }
-            >
+            <div className='pageContent'>
               {childrenWithProps}
             </div>
-            <Footer style={ { position: this.calculateFooterPosition() } } currentUser={ this.props.currentUser } locale={ this.props.locale }  />
+            <Footer currentUser={ this.props.currentUser } locale={ this.props.locale }  />
           </div>
         );
     }

--- a/app/javascript/components/reusable/Footer.js
+++ b/app/javascript/components/reusable/Footer.js
@@ -20,12 +20,10 @@ import contactInfo from '../../ContactInfo';
 class Footer extends Component {
 
   render() {
-    const { style } = this.props;
     return (
       <AppBar
         position='relative'
         classes={ { root: 'footerAppBar' } }
-        style={ style }
       >
         <Toolbar
           classes={ { root: 'footerToolbar' } }
@@ -173,7 +171,6 @@ class Footer extends Component {
 
 Footer.propTypes = {
   currentUser: PropTypes.object.isRequired,
-  style: PropTypes.object.isRequired,
 };
 
 export default Footer;

--- a/app/main.scss
+++ b/app/main.scss
@@ -8,6 +8,7 @@
 @import "scss/_PageHeader.scss";
 @import "scss/_AvailabilitiesTable.scss";
 @import "scss/_CommentContainer.scss";
+@import "scss/_ContentWrapper.scss";
 @import "scss/_ConversationIndexPage.scss";
 @import "scss/_CustomPage.scss";
 @import "scss/_ErrorField.scss";

--- a/app/scss/_ContentWrapper.scss
+++ b/app/scss/_ContentWrapper.scss
@@ -1,0 +1,13 @@
+.pageWrapper {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.pageWrapper > div:first-child, .pageWrapper > header:last-child {
+    flex-shrink: 0;
+}
+
+.pageContent {
+    flex-grow: 1;
+}


### PR DESCRIPTION
Fix for footer appearing in the middle of the page when a volunteer is creating new availabilities. CSS flexbox is now used to keep the footer at the bottom of the page, instead of switching between absolute and relative positioning.
