### PR TITLE
Fixes for timezone support in availability hours, including availabilities that pass midnight

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -1,4 +1,6 @@
 class AvailabilitiesController < ApplicationController
+  include AvailabilitiesSorter
+
   before_action :authenticate_user!
   before_action :check_if_volunteer?, except: [:search]
   before_action :check_if_client?, only: [:search]
@@ -72,13 +74,15 @@ class AvailabilitiesController < ApplicationController
   def index
     user = UserDecorator.new(current_user).simple_decorate
     programs = current_user.programs
-    availabilities = Availability.where(:user => current_user).collect{ |n|
+    availabilities_unsorted = Availability.where(:user => current_user).collect{ |n|
       AvailabilityDecorator.new(n, {
           :timezone => current_user_timezone,
           :user_timezone => current_user_timezone
       }).self_decorate
     }
 
+    availabilities = sort_availabilities(availabilities_unsorted)
+    
     @data = {
         :currentUser => user,
         :programs => programs,
@@ -123,4 +127,5 @@ class AvailabilitiesController < ApplicationController
         :end_time
     )
   end
+
 end

--- a/app/controllers/concerns/availabilities_sorter.rb
+++ b/app/controllers/concerns/availabilities_sorter.rb
@@ -1,0 +1,29 @@
+module AvailabilitiesSorter
+    extend ActiveSupport::Concern
+
+    def sort_availabilities(availabilities_unsorted)
+        availabilities = availabilities_unsorted.sort_by { 
+          |availability| [ get_day_value(availability[:day]), availability[:start_time] ] 
+        }
+    end
+
+    def get_day_value(day) 
+        case day
+        when "Monday"
+          0
+        when "Tuesday"
+          1
+        when "Wednesday"
+          2
+        when "Thursday"
+          3
+        when "Friday"
+          4
+        when "Saturday"
+          5
+        when "Sunday"
+          6
+        end                            
+      end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  include AvailabilitiesSorter
+  
   before_action :authenticate_user!, except: :cities
   before_action :permitted_params, except: :cities
 
@@ -53,17 +55,22 @@ class UsersController < ApplicationController
                                                        timezone: current_user.timezone,
                                                        user_timezone: @user.timezone,
                                                        day: first_day,
-                                                       end_time: '23:59').decorate
+                                                       end_time: '23:59 ' + Time.zone.now.zone).decorate
 
-        availabilities << split_availability
+        if start_and_end_times_differ(split_availability)  
+          availabilities << split_availability
+        end
 
         split_availability_2 = AvailabilityDecorator.new(availability,
                                                          timezone: current_user.timezone,
                                                          user_timezone: @user.timezone,
                                                          day: second_day,
-                                                         start_time: '00:00').decorate
+                                                         start_time: '00:00 '  + Time.zone.now.zone).decorate
 
-        availabilities << split_availability_2
+        if start_and_end_times_differ(split_availability_2)  
+          availabilities << split_availability_2
+        end
+
       else
         availability = AvailabilityDecorator.new(availability,
                                                  timezone: current_user.timezone,
@@ -72,7 +79,7 @@ class UsersController < ApplicationController
         availabilities << availability
       end
     end
-    @availabilities = availabilities
+    @availabilities = sort_availabilities(availabilities)
   end
 
   def get_ten_last_comments
@@ -91,5 +98,9 @@ class UsersController < ApplicationController
 
   def permitted_params
     params.permit(:url_slug)
+  end
+
+  def start_and_end_times_differ(availability) 
+    availability[:start_time] != availability[:end_time]
   end
 end

--- a/app/decorators/availability_decorator.rb
+++ b/app/decorators/availability_decorator.rb
@@ -51,7 +51,7 @@ class AvailabilityDecorator
     offset = current_time.utc_offset/3600
      
     user_time = ActiveSupport::TimeZone[offset].parse(time.to_s)
-    user_time.strftime("%H:%M")
+    user_time.strftime("%H:%M") + ' ' + Time.zone.now.zone
   end 
   
   def start_time

--- a/app/models/contexts/availabilities/creation.rb
+++ b/app/models/contexts/availabilities/creation.rb
@@ -21,6 +21,8 @@ module Contexts
           raise Availabilities::Errors::EndTimeMissing, message
         end
 
+        use_account_timezone(availability[:start_time], availability[:end_time])
+
         parse_times_utc
         parse_times_user_tz
       end
@@ -98,6 +100,19 @@ module Contexts
       def day_month(index)
         "#{I18n.t('date.day_names')[@day_index]}, #{index + 1} Jan 2001"
       end
+
+      def use_account_timezone (start_time, end_time)
+        @availability[:start_time] = parse_account_timezone(start_time)
+        @availability[:end_time] = parse_account_timezone(end_time)
+      end
+
+      def parse_account_timezone(time)
+        account_offset = Time.now.in_time_zone(@timezone).formatted_offset
+        parsed_time = Time.parse(time)
+        datetime_without_timezone = parsed_time.strftime("%Y-%m-%d %H:%M:%S ")
+    
+        with_account_timezone = datetime_without_timezone + account_offset
+      end 
 
       def parse_time(time)
         t = Time.zone.parse(time)


### PR DESCRIPTION
* Prevent availabilities with the same start and end times from being added to search results (e.g. 00:00-00:00 and 23:59-23:59).
* Save availability times based on account's timezone, not browser's timezone
* Sort availability times from Mon - Sun, instead of order added to database
* Show timezone abbreviations in availability hours shown to volunteers and clients
* Update yarn.lock