### PR TITLE
Email login bug

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -74,7 +74,7 @@ class UserMailer < ApplicationMailer
   end
 
   def url
-   "#{domain_name}/sign_in"
+   "#{domain_name}/#{@user.locale}/sign_in"
   end
 
   def admin_email

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
       port: '5000'
   }
 
-  config.base_domain = ENV["DOMAIN_NAME"]
+  config.base_domain = ENV["DOMAIN_NAME"] || "localhost:5000"
 
   config.action_mailer.perform_caching = false
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jason-form": "^1.0.0",
     "joi-browser": "^13.4.0",
     "leaflet": "^1.5.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.19",
     "material-ui": "^0.20.1",
     "moment": "^2.24.0",
     "postcss-cssnext": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5123,10 +5123,10 @@ lodash.unset@^4.5.2:
   resolved "https://registry.yarnpkg.com/lodash.unset/-/lodash.unset-4.5.2.tgz#370d1d3e85b72a7e1b0cdf2d272121306f23e4ed"
   integrity sha1-Nw0dPoW3Kn4bDN8tJyEhMG8j5O0=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.10:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5, lodash@~4.17.10:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 loglevel@^1.6.3:
   version "1.6.3"


### PR DESCRIPTION
User creation confirmation email was generating a sign in link: `https://tutoria.io/sign_in`

Which redirects to `https://tutoria.io/en/undefined/sign_in` because the original link is missing `/en` in the path.

I updated the user mailer model to include the user's 'locale' in order to generate the correct link.

```
  def url
   "#{domain_name}/#{@user.locale}/sign_in"
  end
```

When working with the local development environment, the `domain_name` method was returning nil, so I also updated the development env config `config/environments/development.rb` to default `base_domain` to `localhost:5000` if `ENV['DOMAIN_NAME']` is undefined.

