### PR TITLE
added overflow-wrap to custompage anchor links

### DIFF
--- a/app/scss/_CustomPage.scss
+++ b/app/scss/_CustomPage.scss
@@ -27,4 +27,5 @@
 
 .customPageContainer a {
     color: #29AAE2;
+    overflow-wrap: break-word;
 }


### PR DESCRIPTION
Checked with iphone simulator in xcode and this latest adjustment looks like it is working!

Pretty much just changed the one line: `.customPageContainer a { overflow-wrap: break-word}`

<img width="445" alt="Screen Shot 2020-08-24 at 11 55 50 AM" src="https://user-images.githubusercontent.com/36972296/91067884-788bb900-e601-11ea-949e-e1fc8da94530.png">
