### PR TITLE
Complete availabilities not set up email

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: bundle exec rails s
 webpacker: ./bin/webpack-dev-server
+job: bundle exec rake jobs:work
 
 #web: bundle exec puma -C ./config/puma.rb

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -67,6 +67,11 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: 'Tutoría Password Updated')
   end
 
+  def account_inactive(user)
+    @user = user
+    mail(to: @user.email, subject: 'New account inactive - Tutoría')
+  end
+
   private
 
   def domain_name

--- a/app/models/availability_job.rb
+++ b/app/models/availability_job.rb
@@ -1,0 +1,13 @@
+class AvailabilityJob < Struct.new(:volunteer)
+
+  def availability_email
+    UserMailer.account_inactive(volunteer).deliver_later
+  end
+
+  def perform
+    if !volunteer.availabilities.first
+      availability_email
+    end
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,6 +104,10 @@ class User < ActiveRecord::Base
     if client?
       UserMailer.account_reactivated(self).deliver_later
     else
+      if self.availabilities && !self.availabilities.first
+        availability_job = AvailabilityJob.new(self)
+        Delayed::Job.enqueue(availability_job, 0, 3.days.from_now)
+      end
       UserMailer.account_activated(self).deliver_later
     end
   end

--- a/app/views/user_mailer/account_inactive.html.erb
+++ b/app/views/user_mailer/account_inactive.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<%= image_tag attachments['logo.png'].url %>
+<h1><%= @user.first_name %>,</h1>
+<p>
+  Hope this note finds you well.
+</p>
+<p>
+  We have seen that your profile was activated 3 days ago but you have not entered your availabilities yet. Please note that your profile won't show up in client search results if you do not enter your availabilities.
+</p>
+<p>
+  Thank you.
+</p>
+<p>Team Tutoría</p>
+
+</body>
+</html>

--- a/app/views/user_mailer/account_inactive.text.erb
+++ b/app/views/user_mailer/account_inactive.text.erb
@@ -1,0 +1,10 @@
+<%= @user.first_name %>,
+===============================================
+Hope this note finds you well. 
+
+We have seen that your profile was activated 3 days ago but you have not entered your availabilities yet. Please note that your profile won't show up in client search results if you do not enter your availabilities.
+
+Thank you.
+
+
+Team Tutoría

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,4 +1,8 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
-
+  def account_inactive
+    UserMailer.account_inactive(
+      User.first
+    )
+  end
 end


### PR DESCRIPTION
* When volunteer signs up, if no availabilities are created within three days a reminder e-mail is sent
    * Created availability email worker
    * Checked if availabilities were set after three days
    * Created html and plain text email templates
        * http://localhost:5000/rails/mailers/user_mailer/account_inactive

<img width="1371" alt="Screen Shot 2020-08-26 at 12 31 24 AM" src="https://user-images.githubusercontent.com/61805580/91256887-868f2600-e736-11ea-9fa7-b32ee599740b.png">
