### PR TITLE
Fixes for creating availabilities that cross midnight and into the next day

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  include AvailabilitiesSorter
+  
   before_action :authenticate_user!, except: [:cities, :counts]
   before_action :permitted_params, except: [:cities, :counts]
 
@@ -49,9 +51,13 @@ class UsersController < ApplicationController
     # TODO: please improve
     availabilities = []
     @availabilities.each do |availability|
-      Time.zone = current_user.timezone
-      first_day = availability.start_time.strftime('%A')
-      second_day = availability.end_time.strftime('%A')
+      # parse time with user's currenet utc offset (including daylight savings time)
+      # to catch when dst causes availability period to span into the next day
+      start_time = AvailabilityDecorator.parse_time_users_offset(availability.start_time, current_user.timezone)
+      end_time = AvailabilityDecorator.parse_time_users_offset(availability.end_time, current_user.timezone)
+      
+      first_day = start_time.strftime('%A')
+      second_day = end_time.strftime('%A')
 
       if first_day != second_day
         split_availability = AvailabilityDecorator.new(availability,

--- a/app/decorators/availability_decorator.rb
+++ b/app/decorators/availability_decorator.rb
@@ -40,17 +40,20 @@ class AvailabilityDecorator
   end
 
   def current_user_day
-    Time.zone = @timezone
-    @day ||= Time.zone.local_to_utc(@availability.start_time).strftime("%A")
+    @day ||= AvailabilityDecorator.parse_time_users_offset(@availability.start_time, @timezone).strftime("%A")
   end
-  
-  def get_time(time)
-    Time.zone = @timezone
+
+  def self.parse_time_users_offset(time, timezone)
+    Time.zone = timezone
   
     current_time = Time.zone.now 
     offset = current_time.utc_offset/3600
-     
-    user_time = ActiveSupport::TimeZone[offset].parse(time.to_s)
+    
+    ActiveSupport::TimeZone[offset].parse(time.to_s)
+  end
+ 
+  def get_time(time)
+    user_time = AvailabilityDecorator.parse_time_users_offset(time, @timezone)
     user_time.strftime("%H:%M") + ' ' + Time.zone.now.zone
   end 
   

--- a/app/models/contexts/availabilities/creation.rb
+++ b/app/models/contexts/availabilities/creation.rb
@@ -122,7 +122,16 @@ module Contexts
       def parse_times_utc
         Time.zone = 'UTC'
         @parsed_start_time_utc = parse_time(@availability[:start_time])
-        @parsed_end_time_utc = parse_time(@availability[:end_time])
+        @parsed_end_time_utc = end_date_time_utc(@parsed_start_time_utc, parse_time(@availability[:end_time]))
+      end
+
+      def end_date_time_utc(start_time, end_time)
+        # Use the difference in time between the start and end to find the correct end day
+        # when the end time in utc spans to the next day
+        start_hour_min = Time.parse(@availability[:start_time]).change(sec: 0)
+        end_hour_min = Time.parse(@availability[:end_time]).change(sec: 0)
+        duration = (end_hour_min - start_hour_min) / 1.seconds
+        actual_end_day = start_time + duration.seconds
       end
 
       def parse_times_user_tz


### PR DESCRIPTION
This PR has additional fixes to support availabilities that wrap days in UTC and wrap days due to DST.

* Adding support for when availabilities wrap days in UTC time
* Now uses UTC offset that takes into account DST to correctly handle availabilities that cross into next day due to DST
* Parse hours and minutes only, to avoid errors due to seconds when calculating duration
* Fix to return correct day when DST is in effect for user's timezone