### PR TITLE
added overflow-wrap

### DIFF
--- a/app/scss/_CustomPage.scss
+++ b/app/scss/_CustomPage.scss
@@ -26,5 +26,7 @@
 }
 
 .customPageContainer a {
-    color: #29AAE2;
+  color: #29aae2;
+  overflow-wrap: break-word;
 }
+


### PR DESCRIPTION
Checked with iphone simulator in xcode and this latest adjustment looks like it is working!

Pretty much just changed the one line: .customPageContainer a { overflow-wrap: break-word}

![image](https://user-images.githubusercontent.com/36972296/93839296-82cdc100-fc5a-11ea-9a71-93f727e7af75.png)
