### PR TITLE
Fixes for creating availabilities that cross midnight and into the next day

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -1,4 +1,6 @@
 class AvailabilitiesController < ApplicationController
+  include AvailabilitiesSorter
+
   before_action :authenticate_user!
   before_action :check_if_volunteer?, except: [:search]
   before_action :check_if_client?, only: [:search]
@@ -72,13 +74,15 @@ class AvailabilitiesController < ApplicationController
   def index
     user = UserDecorator.new(current_user).simple_decorate
     programs = current_user.programs
-    availabilities = Availability.where(:user => current_user).collect{ |n|
+    availabilities_unsorted = Availability.where(:user => current_user).collect{ |n|
       AvailabilityDecorator.new(n, {
           :timezone => current_user_timezone,
           :user_timezone => current_user_timezone
       }).self_decorate
     }
 
+    availabilities = sort_availabilities(availabilities_unsorted)
+    
     @data = {
         :currentUser => user,
         :programs => programs,
@@ -123,4 +127,5 @@ class AvailabilitiesController < ApplicationController
         :end_time
     )
   end
+
 end

--- a/app/controllers/concerns/availabilities_sorter.rb
+++ b/app/controllers/concerns/availabilities_sorter.rb
@@ -1,0 +1,29 @@
+module AvailabilitiesSorter
+    extend ActiveSupport::Concern
+
+    def sort_availabilities(availabilities_unsorted)
+        availabilities = availabilities_unsorted.sort_by { 
+          |availability| [ get_day_value(availability[:day]), availability[:start_time] ] 
+        }
+    end
+
+    def get_day_value(day) 
+        case day
+        when "Monday"
+          0
+        when "Tuesday"
+          1
+        when "Wednesday"
+          2
+        when "Thursday"
+          3
+        when "Friday"
+          4
+        when "Saturday"
+          5
+        when "Sunday"
+          6
+        end                            
+      end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,9 +46,13 @@ class UsersController < ApplicationController
     # TODO: please improve
     availabilities = []
     @availabilities.each do |availability|
-      Time.zone = current_user.timezone
-      first_day = availability.start_time.strftime('%A')
-      second_day = availability.end_time.strftime('%A')
+      # parse time with user's currenet utc offset (including daylight savings time)
+      # to catch when dst causes availability period to span into the next day
+      start_time = AvailabilityDecorator.parse_time_users_offset(availability.start_time, current_user.timezone)
+      end_time = AvailabilityDecorator.parse_time_users_offset(availability.end_time, current_user.timezone)
+      
+      first_day = start_time.strftime('%A')
+      second_day = end_time.strftime('%A')
 
       if first_day != second_day
         split_availability = AvailabilityDecorator.new(availability,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  include AvailabilitiesSorter
+  
   before_action :authenticate_user!, except: :cities
   before_action :permitted_params, except: :cities
 
@@ -53,17 +55,22 @@ class UsersController < ApplicationController
                                                        timezone: current_user.timezone,
                                                        user_timezone: @user.timezone,
                                                        day: first_day,
-                                                       end_time: '23:59').decorate
+                                                       end_time: '23:59 ' + Time.zone.now.zone).decorate
 
-        availabilities << split_availability
+        if start_and_end_times_differ(split_availability)  
+          availabilities << split_availability
+        end
 
         split_availability_2 = AvailabilityDecorator.new(availability,
                                                          timezone: current_user.timezone,
                                                          user_timezone: @user.timezone,
                                                          day: second_day,
-                                                         start_time: '00:00').decorate
+                                                         start_time: '00:00 '  + Time.zone.now.zone).decorate
 
-        availabilities << split_availability_2
+        if start_and_end_times_differ(split_availability_2)  
+          availabilities << split_availability_2
+        end
+
       else
         availability = AvailabilityDecorator.new(availability,
                                                  timezone: current_user.timezone,
@@ -72,7 +79,7 @@ class UsersController < ApplicationController
         availabilities << availability
       end
     end
-    @availabilities = availabilities
+    @availabilities = sort_availabilities(availabilities)
   end
 
   def get_ten_last_comments
@@ -91,5 +98,9 @@ class UsersController < ApplicationController
 
   def permitted_params
     params.permit(:url_slug)
+  end
+
+  def start_and_end_times_differ(availability) 
+    availability[:start_time] != availability[:end_time]
   end
 end

--- a/app/decorators/availability_decorator.rb
+++ b/app/decorators/availability_decorator.rb
@@ -51,7 +51,7 @@ class AvailabilityDecorator
     offset = current_time.utc_offset/3600
      
     user_time = ActiveSupport::TimeZone[offset].parse(time.to_s)
-    user_time.strftime("%H:%M")
+    user_time.strftime("%H:%M") + ' ' + Time.zone.now.zone
   end 
   
   def start_time

--- a/app/decorators/availability_decorator.rb
+++ b/app/decorators/availability_decorator.rb
@@ -40,17 +40,20 @@ class AvailabilityDecorator
   end
 
   def current_user_day
-    Time.zone = @timezone
-    @day ||= Time.zone.local_to_utc(@availability.start_time).strftime("%A")
+    @day ||= AvailabilityDecorator.parse_time_users_offset(@availability.start_time, @timezone).strftime("%A")
   end
-  
-  def get_time(time)
-    Time.zone = @timezone
+
+  def self.parse_time_users_offset(time, timezone)
+    Time.zone = timezone
   
     current_time = Time.zone.now 
     offset = current_time.utc_offset/3600
-     
-    user_time = ActiveSupport::TimeZone[offset].parse(time.to_s)
+    
+    ActiveSupport::TimeZone[offset].parse(time.to_s)
+  end
+ 
+  def get_time(time)
+    user_time = AvailabilityDecorator.parse_time_users_offset(time, @timezone)
     user_time.strftime("%H:%M") + ' ' + Time.zone.now.zone
   end 
   

--- a/app/models/contexts/availabilities/creation.rb
+++ b/app/models/contexts/availabilities/creation.rb
@@ -129,7 +129,16 @@ module Contexts
       def parse_times_utc
         Time.zone = 'UTC'
         @parsed_start_time_utc = parse_time(@availability[:start_time])
-        @parsed_end_time_utc = parse_time(@availability[:end_time])
+        @parsed_end_time_utc = end_date_time_utc(@parsed_start_time_utc, parse_time(@availability[:end_time]))
+      end
+
+      def end_date_time_utc(start_time, end_time)
+        # Use the difference in time between the start and end to find the correct end day
+        # when the end time in utc spans to the next day
+        start_hour_min = Time.parse(@availability[:start_time]).change(sec: 0)
+        end_hour_min = Time.parse(@availability[:end_time]).change(sec: 0)
+        duration = (end_hour_min - start_hour_min) / 1.seconds
+        actual_end_day = start_time + duration.seconds
       end
 
       def parse_times_user_tz

--- a/app/models/contexts/availabilities/creation.rb
+++ b/app/models/contexts/availabilities/creation.rb
@@ -21,6 +21,8 @@ module Contexts
           raise Availabilities::Errors::EndTimeMissing, message
         end
 
+        use_account_timezone(availability[:start_time], availability[:end_time])
+
         parse_times_utc
         parse_times_user_tz
       end
@@ -105,6 +107,19 @@ module Contexts
          
         user_time = ActiveSupport::TimeZone[offset].parse(time.to_s)
       end
+
+      def use_account_timezone (start_time, end_time)
+        @availability[:start_time] = parse_account_timezone(start_time)
+        @availability[:end_time] = parse_account_timezone(end_time)
+      end
+
+      def parse_account_timezone(time)
+        account_offset = Time.now.in_time_zone(@timezone).formatted_offset
+        parsed_time = Time.parse(time)
+        datetime_without_timezone = parsed_time.strftime("%Y-%m-%d %H:%M:%S ")
+    
+        with_account_timezone = datetime_without_timezone + account_offset
+      end 
 
       def parse_time(time)
         t = Time.zone.parse(time)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9047,6 +9047,15 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
+  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"


### PR DESCRIPTION
This PR has additional fixes to support availabilities that wrap days in UTC and wrap days due to DST.

* Adding support for when availabilities wrap days in UTC time
* Now uses UTC offset that takes into account DST to correctly handle availabilities that cross into next day due to DST
* Parse hours and minutes only, to avoid errors due to seconds when calculating duration
* Fix to return correct day when DST is in effect for user's timezone
