### PR TITLE
Use a default country on user signup

### DIFF
--- a/app/javascript/components/reusable/withUserForm.js
+++ b/app/javascript/components/reusable/withUserForm.js
@@ -415,7 +415,7 @@ const withUserForm = (WrappedComponent, schema, wrappedProps) => {
                   />
                 )
               }
-              value={ country ? country : 'United States' }
+              value={ country ? country : '' }
               className='userFormInputField country'
               errorText={ this.errorLanguageHandler('country') }
               onChange={ this.changeCountryHandler }
@@ -1388,7 +1388,7 @@ const withUserForm = (WrappedComponent, schema, wrappedProps) => {
       address: '',
       city: '',
       state: '',
-      country: '',
+      country: 'United States',
       first_name: '',
       last_name: '',
       email: '',

--- a/app/javascript/components/schema/SignUpSchema.js
+++ b/app/javascript/components/schema/SignUpSchema.js
@@ -70,7 +70,13 @@ const SignUpSchema = {
   address: Joi.string().allow(''),
   city: Joi.string().allow(''),
   state: Joi.string().allow(''),
-  country: Joi.string().allow(''),
+  country: Joi.string().required().options({
+    language: {
+      any: {
+        empty: 'Please select a country'
+      },
+    }
+  }),
 
   email: Joi.string().email().required().options({
     language: {
@@ -92,7 +98,13 @@ const SignUpSchema = {
     }
   }),
   contact_permission: Joi.boolean(),
-  how_they_found_us: Joi.string().required(),
+  how_they_found_us: Joi.string().required().options({
+    language: {
+      any: {
+        empty: 'Please select an option for how you found us'
+      },
+    }
+  }),
 
   terms_and_conditions: Joi.boolean().valid(true).options({
     language: {


### PR DESCRIPTION
- Fix for issue where United States would appear on the front end, but the country value was blank on the back end/database.
- 'United States' is used for the default and is stored upon user registration, unless the user changes it
- The country field is now required

