### PR TITLE
fixed email url

### DIFF
--- a/app/views/user_mailer/unresponsive_volunteer.html.erb
+++ b/app/views/user_mailer/unresponsive_volunteer.html.erb
@@ -15,7 +15,7 @@
 </p>
 
 <ol>
-  <li> <a href='https:/tutoria.io/en/sign_in'>Sign in</a> to Tutoria </li>
+  <li> <a href='https://tutoria.io/en/sign_in'>Sign in</a> to Tutoria </li>
   <br>
   <li> Reactivate availabilities by going to the Availabilities page.</li>
   <br>


### PR DESCRIPTION
Unresponsive volunteer email had a typo in the template link, this fixes the problem.