### PR TITLE
Increase char limit for new messages

### DIFF
--- a/app/javascript/components/NewMessagePage.js
+++ b/app/javascript/components/NewMessagePage.js
@@ -99,6 +99,7 @@ class NewMessagePage extends Component {
               name='body'
               value={ body }
               className='userFormInputField body'
+              multiLine
               hintText=''
               floatingLabelText={
                 (
@@ -115,7 +116,7 @@ class NewMessagePage extends Component {
             />
           </form>
 
-          <FloatingActionButton disabled={disabled} onClick={ this.handleSubmit } style={ { position: 'absolute', bottom: '-24px', right: '0' } }>
+          <FloatingActionButton disabled={ disabled } onClick={ this.handleSubmit } style={ { position: 'absolute', bottom: '-24px', right: '0' } }>
             <SendIcon />
           </FloatingActionButton>
 

--- a/app/javascript/components/schema/MessageSchema.js
+++ b/app/javascript/components/schema/MessageSchema.js
@@ -9,10 +9,11 @@ const MessageSchema = {
       }
     }
   }),
-  body: Joi.string().allow('').max(248).options({
+  body: Joi.string().required().options({
     language: {
-      string: {
-        max: 'Please keep your message under 248 characters'
+      any: {
+        required: 'Please enter a message',
+        empty: 'Please enter a message',
       }
     }
   }),

--- a/app/scss/_NewMessagePage.scss
+++ b/app/scss/_NewMessagePage.scss
@@ -1,6 +1,10 @@
 .newMessageForm {
     padding: 24px;
     text-align: center;
+
+    .body{
+        text-align: left;
+    }
 }
 
 .recipient {


### PR DESCRIPTION
made the message body field a multiline (textarea), so that it will expand as the user types allowing them to see their whole message on the page, got rid of the 248 char limit and just made the body field required, updated css to push the body label to the top left corner