### PR TITLE
Trello 226 - Order languages by url_slug

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -11,7 +11,9 @@ class RegistrationsController < Devise::RegistrationsController
 
     validate_role_params
     programs = Program.all
-    languages = Language.all
+    # Trello card 226 - @Brian-Tutoria - changing list of "Language(s) I can speak" on sign up page to be ordered by url_slug 
+    # languages = Language.all
+    languages = Language.order('url_slug')
     timezones = ActiveSupport::TimeZone.all.map(&:name)
     timezone_map = get_timezone_mapping
     how_they_found_us_options = @role_url_slug == 'volunteer' \

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -9,7 +9,9 @@ class UserProfilesController < ApplicationController
     end
     user = UserDecorator.new(current_user).updateable
     programs = Program.all
-    languages = Language.all
+    # Trello card 226 - @Brian-Tutoria - changing list of "Language(s) I can speak" on sign up page to be ordered by url_slug 
+    # languages = Language.all
+    languages = Language.order('url_slug')
     timezones = ActiveSupport::TimeZone.all.map(&:name)
     timezone_map = get_timezone_mapping
 


### PR DESCRIPTION
I updated app/controllers/registrations_controller.rb with languages = Langeu.order('url_slug') 